### PR TITLE
fix: worker marking retry tests as started twice

### DIFF
--- a/src/runner/worker.ts
+++ b/src/runner/worker.ts
@@ -141,7 +141,7 @@ export async function runTestWorker(
                 stdout,
                 stderr,
               });
-            } else if (payload.startTime) {
+            } else if (payload.startTime && !reportStarted) {
               reporter.startTest(test, {
                 status: "pending",
                 duration: 0,


### PR DESCRIPTION
The worker will resend the `startTime` message during any retry so the reporter will start the test twice (potentially breaking the UI). This ignores any duplicate start message