### PR TITLE
fix: duplicate snapshots appearing on retries

### DIFF
--- a/src/runner/worker.ts
+++ b/src/runner/worker.ts
@@ -12,6 +12,7 @@ import { expect } from "../test/test.js";
 import { SnapshotStatus } from "../test/matchers/toMatchSnapshot.js";
 import { BaseReporter } from "../reporter/base.js";
 import { poll } from "../utils/poll.js";
+import { flushSnapshotExecutionCache } from "../test/matchers/toMatchSnapshot.js";
 
 type WorkerResult = {
   error?: string;
@@ -239,6 +240,8 @@ const testWorker = async (
   updateSnapshot: boolean,
   importPath: string
 ): Promise<void> => {
+  flushSnapshotExecutionCache();
+
   const startTime = Date.now();
   workerpool.workerEmit({
     startTime,

--- a/src/test/matchers/toMatchSnapshot.ts
+++ b/src/test/matchers/toMatchSnapshot.ts
@@ -80,6 +80,8 @@ const generateSnapshot = (terminal: Terminal, includeColors: boolean) => {
   return `${view}\n${JSON.stringify(Object.fromEntries(shifts), null, 2)}`;
 };
 
+export const flushSnapshotExecutionCache = () => snapshotsIdx.clear();
+
 export async function toMatchSnapshot(
   this: MatcherContext,
   terminal: Terminal,


### PR DESCRIPTION
Snapshot indexes weren't getting reset properly when a test re-runs on the same agent, hence the retry would produce the same snapshots with higher snapshot indexes which would pass since they'd be flagged as new occurrences. This fixes the issue by resetting snapshot indexes between test executions.