### PR TITLE
fix: snapshot failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "glob": "^10.3.10",
         "jest-diff": "^29.7.0",
         "pretty-ms": "^8.0.0",
+        "proper-lockfile": "^4.1.2",
         "which": "^4.0.0",
         "workerpool": "^9.1.0",
         "xterm-headless": "^5.3.0"
@@ -31,6 +32,7 @@
         "@microsoft/tui-test": "file:.",
         "@tsconfig/node18": "^18.2.2",
         "@types/color-convert": "^2.0.3",
+        "@types/proper-lockfile": "^4.1.4",
         "@types/uuid": "^9.0.7",
         "@types/which": "^3.0.3",
         "@typescript-eslint/eslint-plugin": "^6.7.4",
@@ -1068,6 +1070,21 @@
       "version": "2.4.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
@@ -3454,6 +3471,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "license": "MIT",
@@ -3712,6 +3744,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "glob": "^10.3.10",
     "jest-diff": "^29.7.0",
     "pretty-ms": "^8.0.0",
+    "proper-lockfile": "^4.1.2",
     "which": "^4.0.0",
     "workerpool": "^9.1.0",
     "xterm-headless": "^5.3.0"
@@ -51,6 +52,7 @@
     "@microsoft/tui-test": "file:.",
     "@tsconfig/node18": "^18.2.2",
     "@types/color-convert": "^2.0.3",
+    "@types/proper-lockfile": "^4.1.4",
     "@types/uuid": "^9.0.7",
     "@types/which": "^3.0.3",
     "@typescript-eslint/eslint-plugin": "^6.7.4",

--- a/src/reporter/list.ts
+++ b/src/reporter/list.ts
@@ -58,6 +58,7 @@ export class ListReporter extends BaseReporter {
   private _resultIcon(status: TestStatus): string {
     const color = this._resultColor(status);
     switch (status) {
+      case "flaky":
       case "expected":
         return color("✔");
       case "unexpected":

--- a/src/reporter/list.ts
+++ b/src/reporter/list.ts
@@ -7,7 +7,7 @@ import chalk from "chalk";
 import { Shell } from "../terminal/shell.js";
 import { fitToWidth, ansi } from "./utils.js";
 import { TestCase, TestResult, TestStatus } from "../test/testcase.js";
-import { BaseReporter } from "./base.js";
+import { BaseReporter, StaleSnapshotSummary } from "./base.js";
 import { Suite } from "../test/suite.js";
 
 export class ListReporter extends BaseReporter {
@@ -48,8 +48,11 @@ export class ListReporter extends BaseReporter {
     this._updateOrAppendLine(row, line, prefix);
   }
 
-  override end(rootSuite: Suite, obsoleteSnapshots: number): number {
-    return super.end(rootSuite, obsoleteSnapshots);
+  override end(
+    rootSuite: Suite,
+    staleSnapshotSummary: StaleSnapshotSummary
+  ): number {
+    return super.end(rootSuite, staleSnapshotSummary);
   }
 
   private _resultIcon(status: TestStatus): string {

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -239,8 +239,11 @@ export const run = async (options: ExecutionOptions) => {
   } catch {
     /* empty */
   }
-  const obsoleteSnapshots = await cleanSnapshots(allTests, options);
-  const failures = reporter.end(rootSuite, obsoleteSnapshots);
+  const staleSnapshots = await cleanSnapshots(allTests, options);
+  const failures = reporter.end(rootSuite, {
+    obsolete: options.updateSnapshot ? 0 : staleSnapshots,
+    removed: options.updateSnapshot ? staleSnapshots : 0,
+  });
 
   process.exit(failures);
 };

--- a/src/runner/worker.ts
+++ b/src/runner/worker.ts
@@ -55,14 +55,17 @@ const runTest = async (
 
   const allTests = Object.values(globalThis.tests);
   const testPath = test.filePath();
+  const testSignature = test.titlePath().slice(1).join(" › ");
   const signatureIdenticalTests = allTests.filter(
-    (t) => t.filePath() === testPath && t.title === test.title
+    (t) =>
+      t.filePath() === testPath &&
+      t.titlePath().slice(1).join(" › ") === testSignature
   );
   const signatureIdx = signatureIdenticalTests.findIndex(
     (t) => t.id == test.id
   );
   const currentConcurrentTestName = () =>
-    `${test.titlePath().slice(1).join(" › ")} | ${signatureIdx + 1}`;
+    `${testSignature} | ${signatureIdx + 1}`;
 
   expect.setState({
     ...expect.getState(),


### PR DESCRIPTION
This fixes the issue where snapshots overwrite each other (due to `require`'s cache not getting cleared & not proper file locking between processes), fixes an issue where flaky tests had no result icon, & update the base reporter's summary to properly state the difference between an obsolete test and a test that was obsolete and is now removed.