### PR TITLE
refactor: extract terminal emulator behind a backend trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda177466b9524d59f1b12f0dd30b68696788e9992a7e959021c4a0ed96fcf59"
 dependencies = [
  "base64",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "home",
  "libc",
  "log",
@@ -124,11 +124,20 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -190,6 +199,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79fcda08c33bb58b97008b2cdada6622500e949e060f5913361763121abd2416"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "static_assertions",
+ "zmij",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,7 +254,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -498,7 +520,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -627,7 +649,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -676,7 +698,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -689,7 +711,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -706,6 +728,12 @@ dependencies = [
  "libc",
  "rustix 1.1.4",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "scopeguard"
@@ -783,7 +811,9 @@ version = "0.0.1-beta.5"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
+ "bitflags 2.13.1",
  "clap",
+ "compact_str",
  "crossterm",
  "dialoguer",
  "dirs",
@@ -854,6 +884,12 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -943,7 +979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
  "arrayvec",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cursor-icon",
  "log",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,5 @@ serde_json = "1.0.150"
 crossterm = "0.28"
 ttf-parser = { version = "0.25.1", default-features = false, features = ["std"] }
 dialoguer = { version = "0.11", default-features = false }
+compact_str = "0.10.0"
+bitflags = "2.13.1"

--- a/SKILL.md
+++ b/SKILL.md
@@ -163,6 +163,7 @@ shell-use mouse drag 2 2 20 2            # drag from (2,2) to (20,2)
 shell-use cells 0 0 10 1                       # inspect char/fg/bg/flags
 shell-use expect text "ERROR" --fg "#ff0000"   # text present AND red
 shell-use expect text "OK" --fg 2 --bg 0       # ansi-256 fg/bg
+shell-use expect text "plain" --fg default     # asserts the cell set no color
 ```
 
 ## Workflow: snapshot testing

--- a/bindings/js/src/types.ts
+++ b/bindings/js/src/types.ts
@@ -1,5 +1,12 @@
 export type Color = "default" | number | string;
 
+export type UnderlineStyle =
+  | "single"
+  | "double"
+  | "curly"
+  | "dotted"
+  | "dashed";
+
 export type Shell =
   | "bash"
   | "powershell"
@@ -29,9 +36,17 @@ export interface Cell {
   fg: Color;
   bg: Color;
   bold: boolean;
+  dim: boolean;
   italic: boolean;
-  underline: boolean;
   inverse: boolean;
+  invisible: boolean;
+  strike: boolean;
+  /** Always `false` from the alacritty backend, which cannot report blink. */
+  blink: boolean;
+  underline: boolean;
+  underline_style: UnderlineStyle | null;
+  /** `null` means the underline follows the text color. */
+  underline_color: Color | null;
 }
 
 export interface State {

--- a/bindings/js/src/types.ts
+++ b/bindings/js/src/types.ts
@@ -24,6 +24,7 @@ export interface Size {
 export interface Cell {
   x: number;
   y: number;
+  /** The cell's grapheme; `" "` when blank, `""` for the second column of a double-width character. */
   char: string;
   fg: Color;
   bg: Color;

--- a/bindings/js/src/types.ts
+++ b/bindings/js/src/types.ts
@@ -1,6 +1,8 @@
 export type Color = "default" | number | string;
 
+/** `"none"` is a value, not an absence: an un-underlined cell reports it. */
 export type UnderlineStyle =
+  | "none"
   | "single"
   | "double"
   | "curly"
@@ -43,10 +45,11 @@ export interface Cell {
   strike: boolean;
   /** Always `false` from the alacritty backend, which cannot report blink. */
   blink: boolean;
+  /** Shorthand for `underline_style !== "none"`. */
   underline: boolean;
-  underline_style: UnderlineStyle | null;
-  /** `null` means the underline follows the text color. */
-  underline_color: Color | null;
+  underline_style: UnderlineStyle;
+  /** `"default"` means the underline follows the text color. */
+  underline_color: Color;
 }
 
 export interface State {

--- a/bindings/js/src/types.ts
+++ b/bindings/js/src/types.ts
@@ -48,7 +48,11 @@ export interface Cell {
   /** Shorthand for `underline_style !== "none"`. */
   underline: boolean;
   underline_style: UnderlineStyle;
-  /** `"default"` means the underline follows the text color. */
+  /**
+   * `"default"` means the underline follows the text color. Tracked
+   * independently of `underline_style`, so a cell that set SGR 58 without an
+   * underline still reports the color it would use.
+   */
   underline_color: Color;
 }
 

--- a/bindings/python/src/shell_use/types.py
+++ b/bindings/python/src/shell_use/types.py
@@ -28,7 +28,9 @@ class Cell:
     #: Shorthand for ``underline_style != "none"``.
     underline: bool
     underline_style: UnderlineStyle
-    #: ``"default"`` means the underline follows the text color.
+    #: ``"default"`` means the underline follows the text color. Tracked
+    #: independently of ``underline_style``, so a cell that set SGR 58 without
+    #: an underline still reports the color it would use.
     underline_color: Color
 
 

--- a/bindings/python/src/shell_use/types.py
+++ b/bindings/python/src/shell_use/types.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass
 from typing import Any, Dict, Literal, Optional, Union
 
 Color = Union[str, int]
-UnderlineStyle = Literal["single", "double", "curly", "dotted", "dashed"]
+#: ``"none"`` is a value, not an absence: an un-underlined cell reports it.
+UnderlineStyle = Literal["none", "single", "double", "curly", "dotted", "dashed"]
 
 
 @dataclass
@@ -24,10 +25,11 @@ class Cell:
     strike: bool
     #: Always ``False`` from the alacritty backend, which cannot report blink.
     blink: bool
+    #: Shorthand for ``underline_style != "none"``.
     underline: bool
-    underline_style: Optional[UnderlineStyle]
-    #: ``None`` means the underline follows the text color.
-    underline_color: Optional[Color]
+    underline_style: UnderlineStyle
+    #: ``"default"`` means the underline follows the text color.
+    underline_color: Color
 
 
 @dataclass

--- a/bindings/python/src/shell_use/types.py
+++ b/bindings/python/src/shell_use/types.py
@@ -10,6 +10,8 @@ Color = Union[str, int]
 class Cell:
     x: int
     y: int
+    #: The cell's grapheme; ``" "`` when blank, ``""`` for the second column
+    #: of a double-width character.
     char: str
     fg: Color
     bg: Color

--- a/bindings/python/src/shell_use/types.py
+++ b/bindings/python/src/shell_use/types.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Literal, Optional, Union
 
 Color = Union[str, int]
+UnderlineStyle = Literal["single", "double", "curly", "dotted", "dashed"]
 
 
 @dataclass
@@ -16,9 +17,17 @@ class Cell:
     fg: Color
     bg: Color
     bold: bool
+    dim: bool
     italic: bool
-    underline: bool
     inverse: bool
+    invisible: bool
+    strike: bool
+    #: Always ``False`` from the alacritty backend, which cannot report blink.
+    blink: bool
+    underline: bool
+    underline_style: Optional[UnderlineStyle]
+    #: ``None`` means the underline follows the text color.
+    underline_color: Optional[Color]
 
 
 @dataclass

--- a/src/assert/color.rs
+++ b/src/assert/color.rs
@@ -53,43 +53,39 @@ fn parse_hex(hex: &str) -> anyhow::Result<(u8, u8, u8)> {
 }
 
 /// Does a cell's resolved color match the expected color?
-pub fn matches(cell: Color, expected: &Expected) -> bool {
+///
+/// A cell using the terminal default never matches: the default is whatever
+/// the viewer's theme picks, so no concrete value can be claimed for it.
+pub fn matches(cell: Option<Color>, expected: &Expected) -> bool {
+    let Some(cell) = cell else {
+        return false;
+    };
     match expected {
-        Expected::Ansi256(n) => match cell {
-            Color::Default => *n == 0,
-            Color::Idx(i) => i == *n,
-            Color::Rgb(r, g, b) => rgb_to_ansi256(r, g, b) == *n,
-        },
+        Expected::Ansi256(n) => cell.to_index() == *n,
         Expected::Hex(er, eg, eb) | Expected::Rgb(er, eg, eb) => {
-            let (er, eg, eb) = (*er, *eg, *eb);
-            match cell {
-                Color::Default => er == 0 && eg == 0 && eb == 0,
-                Color::Idx(i) => {
-                    let (r, g, b) = ansi256_to_rgb(i);
-                    r == er && g == eg && b == eb
-                }
-                Color::Rgb(r, g, b) => r == er && g == eg && b == eb,
-            }
+            let rgb = match cell {
+                Color::Rgb(r, g, b) => (r, g, b),
+                c => ansi256_to_rgb(c.to_index()),
+            };
+            rgb == (*er, *eg, *eb)
         }
     }
 }
 
 /// Render a cell's color in the same space as the expected value, for messages.
-pub fn describe_cell(cell: Color, expected: &Expected) -> String {
+pub fn describe_cell(cell: Option<Color>, expected: &Expected) -> String {
+    let Some(cell) = cell else {
+        return "default".to_string();
+    };
     match expected {
-        Expected::Ansi256(_) => match cell {
-            Color::Default => "0".to_string(),
-            Color::Idx(i) => i.to_string(),
-            Color::Rgb(r, g, b) => rgb_to_ansi256(r, g, b).to_string(),
-        },
-        _ => match cell {
-            Color::Default => "#000000".to_string(),
-            Color::Idx(i) => {
-                let (r, g, b) = ansi256_to_rgb(i);
-                format!("#{r:02x}{g:02x}{b:02x}")
-            }
-            Color::Rgb(r, g, b) => format!("#{r:02x}{g:02x}{b:02x}"),
-        },
+        Expected::Ansi256(_) => cell.to_index().to_string(),
+        _ => {
+            let (r, g, b) = match cell {
+                Color::Rgb(r, g, b) => (r, g, b),
+                c => ansi256_to_rgb(c.to_index()),
+            };
+            format!("#{r:02x}{g:02x}{b:02x}")
+        }
     }
 }
 
@@ -181,10 +177,23 @@ mod tests {
 
     #[test]
     fn matches_palette_and_default() {
-        assert!(matches(Color::Idx(9), &Expected::Ansi256(9)));
-        assert!(!matches(Color::Idx(2), &Expected::Ansi256(9)));
-        assert!(matches(Color::Default, &Expected::Ansi256(0)));
-        assert!(matches(Color::Rgb(255, 0, 0), &Expected::Rgb(255, 0, 0)));
+        let idx = |i| Some(Color::from_index(i));
+        assert!(matches(idx(9), &Expected::Ansi256(9)));
+        assert!(!matches(idx(2), &Expected::Ansi256(9)));
+        assert!(matches(idx(196), &Expected::Ansi256(196)));
+        assert!(matches(
+            Some(Color::Rgb(255, 0, 0)),
+            &Expected::Rgb(255, 0, 0)
+        ));
+    }
+
+    /// A default-colored cell used to match `--fg 0`, claiming it was black
+    /// when the theme actually paints it light gray.
+    #[test]
+    fn default_color_matches_nothing() {
+        assert!(!matches(None, &Expected::Ansi256(0)));
+        assert!(!matches(None, &Expected::Hex(0, 0, 0)));
+        assert_eq!(describe_cell(None, &Expected::Ansi256(0)), "default");
     }
 
     #[test]

--- a/src/assert/color.rs
+++ b/src/assert/color.rs
@@ -1,6 +1,6 @@
 //! Color parsing and comparison for `expect --fg/--bg`.
 
-use super::super::terminal::emu::Color;
+use super::super::terminal::cell::Color;
 
 #[derive(Debug, Clone)]
 pub enum Expected {
@@ -161,7 +161,7 @@ pub fn rgb_to_ansi256(r: u8, g: u8, b: u8) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::terminal::emu::Color;
+    use crate::terminal::cell::Color;
 
     #[test]
     fn parse_forms() {

--- a/src/assert/color.rs
+++ b/src/assert/color.rs
@@ -4,6 +4,8 @@ use super::super::terminal::cell::Color;
 
 #[derive(Debug, Clone)]
 pub enum Expected {
+    /// The terminal's default color, i.e. the cell set no color of its own.
+    Default,
     Ansi256(u8),
     Hex(u8, u8, u8),
     Rgb(u8, u8, u8),
@@ -12,6 +14,9 @@ pub enum Expected {
 impl Expected {
     pub fn parse(s: &str) -> anyhow::Result<Self> {
         let s = s.trim();
+        if s.eq_ignore_ascii_case("default") {
+            return Ok(Expected::Default);
+        }
         if let Some(hex) = s.strip_prefix('#') {
             let (r, g, b) = parse_hex(hex).map_err(|_| invalid(s))?;
             return Ok(Expected::Hex(r, g, b));
@@ -30,6 +35,7 @@ impl Expected {
 
     pub fn describe(&self) -> String {
         match self {
+            Expected::Default => "default".to_string(),
             Expected::Ansi256(n) => n.to_string(),
             Expected::Hex(r, g, b) => format!("#{r:02x}{g:02x}{b:02x}"),
             Expected::Rgb(r, g, b) => format!("{r},{g},{b}"),
@@ -39,7 +45,9 @@ impl Expected {
 
 /// A consistent, enumerated error for any unparseable color value.
 fn invalid(got: &str) -> anyhow::Error {
-    anyhow::anyhow!("color must be ansi256 (0-255), hex (#rrggbb), or rgb (r,g,b) (got: \"{got}\")")
+    anyhow::anyhow!(
+        "color must be \"default\", ansi256 (0-255), hex (#rrggbb), or rgb (r,g,b) (got: \"{got}\")"
+    )
 }
 
 fn parse_hex(hex: &str) -> anyhow::Result<(u8, u8, u8)> {
@@ -54,21 +62,24 @@ fn parse_hex(hex: &str) -> anyhow::Result<(u8, u8, u8)> {
 
 /// Does a cell's resolved color match the expected color?
 ///
-/// A cell using the terminal default never matches: the default is whatever
-/// the viewer's theme picks, so no concrete value can be claimed for it.
+/// A cell that set no color of its own matches only `default`. It cannot match
+/// a concrete value, because which value it paints is the viewer's theme's
+/// choice and not something the grid knows.
 pub fn matches(cell: Option<Color>, expected: &Expected) -> bool {
     let Some(cell) = cell else {
-        return false;
+        return matches!(expected, Expected::Default);
     };
     match expected {
+        Expected::Default => false,
         Expected::Ansi256(n) => cell.to_index() == *n,
-        Expected::Hex(er, eg, eb) | Expected::Rgb(er, eg, eb) => {
-            let rgb = match cell {
-                Color::Rgb(r, g, b) => (r, g, b),
-                c => ansi256_to_rgb(c.to_index()),
-            };
-            rgb == (*er, *eg, *eb)
-        }
+        Expected::Hex(er, eg, eb) | Expected::Rgb(er, eg, eb) => rgb_of(cell) == (*er, *eg, *eb),
+    }
+}
+
+fn rgb_of(c: Color) -> (u8, u8, u8) {
+    match c {
+        Color::Rgb(r, g, b) => (r, g, b),
+        c => ansi256_to_rgb(c.to_index()),
     }
 }
 
@@ -78,12 +89,9 @@ pub fn describe_cell(cell: Option<Color>, expected: &Expected) -> String {
         return "default".to_string();
     };
     match expected {
-        Expected::Ansi256(_) => cell.to_index().to_string(),
+        Expected::Default | Expected::Ansi256(_) => cell.to_index().to_string(),
         _ => {
-            let (r, g, b) = match cell {
-                Color::Rgb(r, g, b) => (r, g, b),
-                c => ansi256_to_rgb(c.to_index()),
-            };
+            let (r, g, b) = rgb_of(cell);
             format!("#{r:02x}{g:02x}{b:02x}")
         }
     }
@@ -188,12 +196,30 @@ mod tests {
     }
 
     /// A default-colored cell used to match `--fg 0`, claiming it was black
-    /// when the theme actually paints it light gray.
+    /// when the theme actually paints it light gray. It now matches only the
+    /// `default` keyword, which is the way to assert on it.
     #[test]
-    fn default_color_matches_nothing() {
+    fn default_color_matches_only_default() {
         assert!(!matches(None, &Expected::Ansi256(0)));
         assert!(!matches(None, &Expected::Hex(0, 0, 0)));
+        assert!(matches(None, &Expected::Default));
         assert_eq!(describe_cell(None, &Expected::Ansi256(0)), "default");
+    }
+
+    #[test]
+    fn a_colored_cell_is_not_default() {
+        let red = Some(Color::from_index(1));
+        assert!(!matches(red, &Expected::Default));
+        assert!(matches(red, &Expected::Ansi256(1)));
+        assert!(matches!(
+            Expected::parse("default").unwrap(),
+            Expected::Default
+        ));
+        assert!(matches!(
+            Expected::parse("DEFAULT").unwrap(),
+            Expected::Default
+        ));
+        assert_eq!(describe_cell(red, &Expected::Default), "1");
     }
 
     #[test]

--- a/src/assert/color.rs
+++ b/src/assert/color.rs
@@ -2,6 +2,9 @@
 
 use super::super::terminal::cell::Color;
 
+/// The spelling of [`Expected::Default`], on the command line and in messages.
+pub const DEFAULT: &str = "default";
+
 #[derive(Debug, Clone)]
 pub enum Expected {
     /// The terminal's default color, i.e. the cell set no color of its own.
@@ -14,7 +17,7 @@ pub enum Expected {
 impl Expected {
     pub fn parse(s: &str) -> anyhow::Result<Self> {
         let s = s.trim();
-        if s.eq_ignore_ascii_case("default") {
+        if s.eq_ignore_ascii_case(DEFAULT) {
             return Ok(Expected::Default);
         }
         if let Some(hex) = s.strip_prefix('#') {
@@ -35,7 +38,7 @@ impl Expected {
 
     pub fn describe(&self) -> String {
         match self {
-            Expected::Default => "default".to_string(),
+            Expected::Default => DEFAULT.to_string(),
             Expected::Ansi256(n) => n.to_string(),
             Expected::Hex(r, g, b) => format!("#{r:02x}{g:02x}{b:02x}"),
             Expected::Rgb(r, g, b) => format!("{r},{g},{b}"),
@@ -46,7 +49,7 @@ impl Expected {
 /// A consistent, enumerated error for any unparseable color value.
 fn invalid(got: &str) -> anyhow::Error {
     anyhow::anyhow!(
-        "color must be \"default\", ansi256 (0-255), hex (#rrggbb), or rgb (r,g,b) (got: \"{got}\")"
+        "color must be \"{DEFAULT}\", ansi256 (0-255), hex (#rrggbb), or rgb (r,g,b) (got: \"{got}\")"
     )
 }
 
@@ -86,7 +89,7 @@ fn rgb_of(c: Color) -> (u8, u8, u8) {
 /// Render a cell's color in the same space as the expected value, for messages.
 pub fn describe_cell(cell: Option<Color>, expected: &Expected) -> String {
     let Some(cell) = cell else {
-        return "default".to_string();
+        return DEFAULT.to_string();
     };
     match expected {
         Expected::Default | Expected::Ansi256(_) => cell.to_index().to_string(),

--- a/src/assert/snapshot.rs
+++ b/src/assert/snapshot.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{json, Map, Value};
 
-use super::super::terminal::cell::{Color, EmuCell};
+use super::super::terminal::cell::{Attrs, Color, EmuCell};
 
 pub enum SnapshotStatus {
     Passed,
@@ -27,11 +27,11 @@ fn snapshot_path(base: &Path, name: &str) -> PathBuf {
     snapshot_dir(base).join(format!("{}.snap", sanitize(name)))
 }
 
-fn color_value(c: Color) -> Value {
+fn color_value(c: Option<Color>) -> Value {
     match c {
-        Color::Default => Value::String("default".to_string()),
-        Color::Idx(i) => json!(i),
-        Color::Rgb(r, g, b) => Value::String(format!("#{r:02x}{g:02x}{b:02x}")),
+        None => Value::String("default".to_string()),
+        Some(Color::Rgb(r, g, b)) => Value::String(format!("#{r:02x}{g:02x}{b:02x}")),
+        Some(c) => json!(c.to_index()),
     }
 }
 
@@ -43,43 +43,27 @@ fn shift(prev: &EmuCell, cur: &EmuCell) -> Map<String, Value> {
     if prev.bg != cur.bg {
         m.insert("bg".into(), color_value(cur.bg));
     }
-    if prev.bold != cur.bold {
-        m.insert("bold".into(), json!(cur.bold));
+    for (attr, key) in [
+        (Attrs::BOLD, "bold"),
+        (Attrs::DIM, "dim"),
+        (Attrs::ITALIC, "italic"),
+        (Attrs::INVERSE, "inverse"),
+        (Attrs::INVISIBLE, "invisible"),
+        (Attrs::STRIKE, "strike"),
+        (Attrs::BLINK, "blink"),
+    ] {
+        if prev.has(attr) != cur.has(attr) {
+            m.insert(key.into(), json!(cur.has(attr)));
+        }
     }
-    if prev.dim != cur.dim {
-        m.insert("dim".into(), json!(cur.dim));
-    }
-    if prev.italic != cur.italic {
-        m.insert("italic".into(), json!(cur.italic));
-    }
-    if prev.underline != cur.underline {
-        m.insert("underline".into(), json!(cur.underline));
-    }
-    if prev.inverse != cur.inverse {
-        m.insert("inverse".into(), json!(cur.inverse));
-    }
-    if prev.invisible != cur.invisible {
-        m.insert("invisible".into(), json!(cur.invisible));
-    }
-    if prev.strike != cur.strike {
-        m.insert("strike".into(), json!(cur.strike));
+    if prev.underline.is_some() != cur.underline.is_some() {
+        m.insert("underline".into(), json!(cur.underline.is_some()));
     }
     m
 }
 
 fn baseline() -> EmuCell {
-    EmuCell {
-        ch: String::new(),
-        fg: Color::Default,
-        bg: Color::Default,
-        bold: false,
-        dim: false,
-        italic: false,
-        underline: false,
-        inverse: false,
-        invisible: false,
-        strike: false,
-    }
+    EmuCell::blank()
 }
 
 /// Serialize a grid into a boxed text view plus (optionally) a color shift map.

--- a/src/assert/snapshot.rs
+++ b/src/assert/snapshot.rs
@@ -29,7 +29,7 @@ fn snapshot_path(base: &Path, name: &str) -> PathBuf {
 
 fn color_value(c: Option<Color>) -> Value {
     match c {
-        None => Value::String("default".to_string()),
+        None => Value::String(crate::assert::color::DEFAULT.to_string()),
         Some(Color::Rgb(r, g, b)) => Value::String(format!("#{r:02x}{g:02x}{b:02x}")),
         Some(c) => json!(c.to_index()),
     }
@@ -56,8 +56,11 @@ fn shift(prev: &EmuCell, cur: &EmuCell) -> Map<String, Value> {
             m.insert(key.into(), json!(cur.has(attr)));
         }
     }
-    if prev.underline.is_underlined() != cur.underline.is_underlined() {
-        m.insert("underline".into(), json!(cur.underline.is_underlined()));
+    // The style, not a boolean: a curly underline and a single one are
+    // different renderings, and a snapshot that only recorded "underlined"
+    // would pass when one silently became the other.
+    if prev.underline != cur.underline {
+        m.insert("underline".into(), json!(cur.underline.name()));
     }
     m
 }
@@ -168,5 +171,34 @@ mod tests {
             cell(" "),
         ]];
         assert_eq!(serialize(&rows, 6, false), "╭──────╮\n│你b   │\n╰──────╯");
+    }
+
+    /// Snapshots recorded a bare "is underlined", so a curly underline turning
+    /// single left the snapshot passing. The style name is recorded instead.
+    #[test]
+    fn a_shift_between_underline_styles_is_recorded() {
+        use crate::terminal::cell::UnderlineStyle;
+        let styled = |u| EmuCell {
+            underline: u,
+            ..EmuCell::blank()
+        };
+        let curly = shift(
+            &styled(UnderlineStyle::Single),
+            &styled(UnderlineStyle::Curly),
+        );
+        assert_eq!(curly.get("underline"), Some(&json!("curly")));
+        assert_eq!(
+            shift(
+                &styled(UnderlineStyle::Curly),
+                &styled(UnderlineStyle::None)
+            )
+            .get("underline"),
+            Some(&json!("none"))
+        );
+        assert!(shift(
+            &styled(UnderlineStyle::Curly),
+            &styled(UnderlineStyle::Curly)
+        )
+        .is_empty());
     }
 }

--- a/src/assert/snapshot.rs
+++ b/src/assert/snapshot.rs
@@ -74,7 +74,10 @@ pub fn serialize(rows: &[Vec<EmuCell>], cols: u16, include_colors: bool) -> Stri
     for (y, row) in rows.iter().enumerate() {
         let mut line = String::with_capacity(cols as usize);
         for (x, cell) in row.iter().enumerate() {
-            line.push_str(if cell.ch.is_empty() { " " } else { &cell.ch });
+            // A continuation contributes nothing, exactly as in
+            // `rows_to_strings`: the wide char to its left already spans this
+            // column, so giving it a filler widens the row past the box.
+            line.push_str(&cell.ch);
             let s = shift(&prev, cell);
             if !s.is_empty() {
                 shifts.insert(format!("{x},{y}"), Value::Object(s));
@@ -136,4 +139,37 @@ pub fn compare(
         expected: existing.to_string(),
         actual: trimmed.to_string(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::terminal::cell::CONTINUATION;
+
+    fn cell(s: &str) -> EmuCell {
+        EmuCell {
+            ch: s.into(),
+            ..EmuCell::blank()
+        }
+    }
+
+    /// A wide char spans two columns on its own. Rendering a filler for the
+    /// continuation pushed every later column right and left the content line
+    /// one column wider than the frame drawn around it, so any snapshot
+    /// holding a wide char was written misaligned and compared against that.
+    #[test]
+    fn a_wide_char_does_not_overflow_the_frame() {
+        let rows = vec![vec![
+            cell("你"),
+            cell(CONTINUATION),
+            cell("b"),
+            cell(" "),
+            cell(" "),
+            cell(" "),
+        ]];
+        assert_eq!(
+            serialize(&rows, 6, false),
+            "╭──────╮\n│你b   │\n╰──────╯"
+        );
+    }
 }

--- a/src/assert/snapshot.rs
+++ b/src/assert/snapshot.rs
@@ -56,8 +56,8 @@ fn shift(prev: &EmuCell, cur: &EmuCell) -> Map<String, Value> {
             m.insert(key.into(), json!(cur.has(attr)));
         }
     }
-    if prev.underline.is_some() != cur.underline.is_some() {
-        m.insert("underline".into(), json!(cur.underline.is_some()));
+    if prev.underline.is_underlined() != cur.underline.is_underlined() {
+        m.insert("underline".into(), json!(cur.underline.is_underlined()));
     }
     m
 }
@@ -167,9 +167,6 @@ mod tests {
             cell(" "),
             cell(" "),
         ]];
-        assert_eq!(
-            serialize(&rows, 6, false),
-            "╭──────╮\n│你b   │\n╰──────╯"
-        );
+        assert_eq!(serialize(&rows, 6, false), "╭──────╮\n│你b   │\n╰──────╯");
     }
 }

--- a/src/assert/snapshot.rs
+++ b/src/assert/snapshot.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{json, Map, Value};
 
-use super::super::terminal::emu::{Color, EmuCell};
+use super::super::terminal::cell::{Color, EmuCell};
 
 pub enum SnapshotStatus {
     Passed,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -419,10 +419,12 @@ pub enum ExpectCmd {
         /// Invert: assert the text is NOT present.
         #[arg(long)]
         not: bool,
-        /// Require this foreground color on the match.
+        /// Require this foreground color on the match: `default`, an ansi256
+        /// index (0-255), hex (#rrggbb), or rgb (r,g,b).
         #[arg(long)]
         fg: Option<String>,
-        /// Require this background color on the match.
+        /// Require this background color on the match: `default`, an ansi256
+        /// index (0-255), hex (#rrggbb), or rgb (r,g,b).
         #[arg(long)]
         bg: Option<String>,
         /// Timeout in milliseconds.

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -469,7 +469,7 @@ fn cell_json(x: u16, y: u16, cell: &EmuCell) -> serde_json::Value {
 /// them stays internal and the language bindings are unaffected.
 fn color_json(c: Option<Color>) -> serde_json::Value {
     match c {
-        None => json!("default"),
+        None => json!(crate::assert::color::DEFAULT),
         Some(Color::Rgb(r, g, b)) => json!(format!("#{r:02x}{g:02x}{b:02x}")),
         Some(c) => json!(c.to_index()),
     }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -20,7 +20,7 @@ use crate::input::{keys, mouse};
 use crate::ipc;
 use crate::monitor;
 use crate::protocol::{ErrorKind, GetField, MouseAction, Request, Response};
-use crate::terminal::cell::{rows_to_strings, Attrs, Color, EmuCell};
+use crate::terminal::cell::{rows_to_strings, Attrs, Color, EmuCell, UnderlineStyle};
 use crate::terminal::locator::{self, Pattern};
 use logger::Logger;
 use session::{Session, TermState};
@@ -430,21 +430,41 @@ fn cells(s: &Session, x: u16, y: u16, w: u16, h: u16) -> Response {
     for row in y..y.saturating_add(h.max(1)) {
         for col in x..x.saturating_add(w.max(1)) {
             if let Some(cell) = rows.get(row as usize).and_then(|r| r.get(col as usize)) {
-                out.push(json!({
-                    "x": col,
-                    "y": row,
-                    "char": cell.ch.as_str(),
-                    "fg": color_json(cell.fg),
-                    "bg": color_json(cell.bg),
-                    "bold": cell.has(Attrs::BOLD),
-                    "italic": cell.has(Attrs::ITALIC),
-                    "underline": cell.underline.is_some(),
-                    "inverse": cell.has(Attrs::INVERSE),
-                }));
+                out.push(cell_json(col, row, cell));
             }
         }
     }
     Response::with(json!({ "cells": out }))
+}
+
+/// One cell in wire form. Every attribute the neutral model carries is
+/// reported, including ones no current backend can source, so a client can be
+/// written against the full vocabulary rather than against alacritty.
+fn cell_json(x: u16, y: u16, cell: &EmuCell) -> serde_json::Value {
+    json!({
+        "x": x,
+        "y": y,
+        "char": cell.ch.as_str(),
+        "fg": color_json(cell.fg),
+        "bg": color_json(cell.bg),
+        "bold": cell.has(Attrs::BOLD),
+        "dim": cell.has(Attrs::DIM),
+        "italic": cell.has(Attrs::ITALIC),
+        "inverse": cell.has(Attrs::INVERSE),
+        "invisible": cell.has(Attrs::INVISIBLE),
+        "strike": cell.has(Attrs::STRIKE),
+        "blink": cell.has(Attrs::BLINK),
+        "underline": cell.underline.is_some(),
+        "underline_style": cell.underline.map(|u| match u.style {
+            UnderlineStyle::Single => "single",
+            UnderlineStyle::Double => "double",
+            UnderlineStyle::Curly => "curly",
+            UnderlineStyle::Dotted => "dotted",
+            UnderlineStyle::Dashed => "dashed",
+        }),
+        // `null` means the underline follows the text color.
+        "underline_color": cell.underline.and_then(|u| u.color).map(|c| color_json(Some(c))),
+    })
 }
 
 /// Wire form: `"default"`, a 256-color index, or `"#rrggbb"`. Named and
@@ -839,5 +859,56 @@ fn format_timeout(timeout_ms: u64) -> String {
         format!("{}s", timeout_ms / 1_000)
     } else {
         format!("{timeout_ms}ms")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::terminal::cell::{NamedColor, Underline};
+
+    /// Every attribute in the vocabulary reaches the wire, including ones the
+    /// alacritty backend can never source (blink), so clients written against
+    /// the full model keep working when another backend starts reporting them.
+    #[test]
+    fn cell_json_reports_the_whole_vocabulary() {
+        let cell = EmuCell {
+            ch: "x".into(),
+            fg: Some(Color::Named(NamedColor::Red)),
+            bg: Some(Color::Idx(196)),
+            underline: Some(Underline {
+                style: UnderlineStyle::Curly,
+                color: Some(Color::Rgb(1, 2, 3)),
+            }),
+            attrs: Attrs::all(),
+        };
+        let v = cell_json(3, 4, &cell);
+        assert_eq!(v["x"], json!(3));
+        assert_eq!(v["char"], json!("x"));
+        assert_eq!(v["fg"], json!(1));
+        assert_eq!(v["bg"], json!(196));
+        for key in [
+            "bold",
+            "dim",
+            "italic",
+            "inverse",
+            "invisible",
+            "strike",
+            "blink",
+            "underline",
+        ] {
+            assert_eq!(v[key], json!(true), "{key} must be reported");
+        }
+        assert_eq!(v["underline_style"], json!("curly"));
+        assert_eq!(v["underline_color"], json!("#010203"));
+    }
+
+    #[test]
+    fn cell_json_blank_cell_has_no_underline() {
+        let v = cell_json(0, 0, &EmuCell::blank());
+        assert_eq!(v["underline"], json!(false));
+        assert_eq!(v["underline_style"], serde_json::Value::Null);
+        assert_eq!(v["underline_color"], serde_json::Value::Null);
+        assert_eq!(v["blink"], json!(false));
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -20,7 +20,7 @@ use crate::input::{keys, mouse};
 use crate::ipc;
 use crate::monitor;
 use crate::protocol::{ErrorKind, GetField, MouseAction, Request, Response};
-use crate::terminal::emu::{rows_to_strings, Color, EmuCell};
+use crate::terminal::cell::{rows_to_strings, Color, EmuCell};
 use crate::terminal::locator::{self, Pattern};
 use logger::Logger;
 use session::{Session, TermState};
@@ -313,7 +313,7 @@ fn wait_ready(s: &Session) {
     loop {
         {
             let st = s.state.lock().unwrap();
-            if st.emu.tracker().is_ready() || st.exited.is_some() {
+            if st.tracker.is_ready() || st.exited.is_some() {
                 return;
             }
         }
@@ -415,11 +415,11 @@ fn state(s: &Session) -> Response {
         "cols": cols,
         "rows": rows,
         "cursor": { "x": cx, "y": cy },
-        "cwd": st.emu.tracker().cwd(),
-        "last_command": st.emu.tracker().last_command(),
-        "last_exit": st.emu.tracker().last_exit(),
+        "cwd": st.tracker.cwd(),
+        "last_command": st.tracker.last_command(),
+        "last_exit": st.tracker.last_exit(),
         "exited": st.exited,
-        "ready": st.emu.tracker().is_ready(),
+        "ready": st.tracker.is_ready(),
         "text": text,
     }))
 }
@@ -458,10 +458,10 @@ fn color_json(c: Color) -> serde_json::Value {
 fn get(s: &Session, field: GetField) -> Response {
     let st = s.state.lock().unwrap();
     let value = match field {
-        GetField::Command => json!(st.emu.tracker().last_command()),
-        GetField::Output => json!(st.emu.tracker().last_output()),
-        GetField::ExitCode => json!(st.emu.tracker().last_exit()),
-        GetField::Cwd => json!(st.emu.tracker().cwd()),
+        GetField::Command => json!(st.tracker.last_command()),
+        GetField::Output => json!(st.tracker.last_output()),
+        GetField::ExitCode => json!(st.tracker.last_exit()),
+        GetField::Cwd => json!(st.tracker.cwd()),
         GetField::Cursor => {
             let (x, y) = st.emu.cursor();
             json!({ "x": x, "y": y })
@@ -604,15 +604,15 @@ fn wait_idle(s: &Session, timeout_ms: u64) -> Response {
 
 fn wait_command(s: &Session, timeout_ms: u64) -> Response {
     let quiet = Duration::from_millis(300);
-    let baseline = s.state.lock().unwrap().emu.tracker().finished_count();
+    let baseline = s.state.lock().unwrap().tracker.finished_count();
     let ok = poll_until(
         || {
             let st = s.state.lock().unwrap();
-            if st.exited.is_some() || st.emu.tracker().finished_count() > baseline {
+            if st.exited.is_some() || st.tracker.finished_count() > baseline {
                 return true;
             }
             let idle = st.last_change.elapsed() >= quiet;
-            idle && (!st.emu.tracker().started() || st.emu.tracker().is_ready())
+            idle && (!st.tracker.started() || st.tracker.is_ready())
         },
         timeout_ms,
     );
@@ -748,10 +748,10 @@ fn check_colors(
 
 fn expect_exit_code(s: &Session, code: i32) -> Response {
     poll_until(
-        || s.state.lock().unwrap().emu.tracker().last_exit().is_some(),
+        || s.state.lock().unwrap().tracker.last_exit().is_some(),
         config::DEFAULT_EXPECT_TIMEOUT_MS,
     );
-    let actual = s.state.lock().unwrap().emu.tracker().last_exit();
+    let actual = s.state.lock().unwrap().tracker.last_exit();
     match actual {
         Some(a) if a == code => Response::ok(),
         Some(a) => Response::assertion(format!("expected exit code {code}, got {a}")),
@@ -764,8 +764,7 @@ fn expect_output(s: &Session, text: &str, regex: bool) -> Response {
         .state
         .lock()
         .unwrap()
-        .emu
-        .tracker()
+        .tracker
         .last_output()
         .map(|o| o.to_string());
     let Some(output) = output else {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -454,13 +454,13 @@ fn cell_json(x: u16, y: u16, cell: &EmuCell) -> serde_json::Value {
         "invisible": cell.has(Attrs::INVISIBLE),
         "strike": cell.has(Attrs::STRIKE),
         "blink": cell.has(Attrs::BLINK),
-        "underline": cell.underline.is_some(),
-        // Never null: an absent underline is the "none" style, and an
+        "underline": cell.underline.is_underlined(),
+        // Never null: an un-underlined cell is the "none" style, and an
         // underline that follows the text color is "default", the same
         // sentinel `fg` and `bg` use. A client can switch on the string
         // without a null check.
-        "underline_style": cell.underline.map_or("none", |u| u.style.name()),
-        "underline_color": color_json(cell.underline.and_then(|u| u.color)),
+        "underline_style": cell.underline.name(),
+        "underline_color": color_json(cell.underline_color),
     })
 }
 
@@ -862,7 +862,7 @@ fn format_timeout(timeout_ms: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::terminal::cell::{NamedColor, Underline, UnderlineStyle};
+    use crate::terminal::cell::{NamedColor, UnderlineStyle};
 
     /// Every attribute in the vocabulary reaches the wire, including ones the
     /// alacritty backend can never source (blink), so clients written against
@@ -873,10 +873,8 @@ mod tests {
             ch: "x".into(),
             fg: Some(Color::Named(NamedColor::Red)),
             bg: Some(Color::Idx(196)),
-            underline: Some(Underline {
-                style: UnderlineStyle::Curly,
-                color: Some(Color::Rgb(1, 2, 3)),
-            }),
+            underline: UnderlineStyle::Curly,
+            underline_color: Some(Color::Rgb(1, 2, 3)),
             attrs: Attrs::all(),
         };
         let v = cell_json(3, 4, &cell);
@@ -913,10 +911,8 @@ mod tests {
         // Underlined, but with no color of its own: it follows the text color,
         // which is the same thing `fg: "default"` means.
         let cell = EmuCell {
-            underline: Some(Underline {
-                style: UnderlineStyle::Single,
-                color: None,
-            }),
+            underline: UnderlineStyle::Single,
+            underline_color: None,
             ..EmuCell::blank()
         };
         let v = cell_json(0, 0, &cell);

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -20,7 +20,7 @@ use crate::input::{keys, mouse};
 use crate::ipc;
 use crate::monitor;
 use crate::protocol::{ErrorKind, GetField, MouseAction, Request, Response};
-use crate::terminal::cell::{rows_to_strings, Color, EmuCell};
+use crate::terminal::cell::{rows_to_strings, Attrs, Color, EmuCell};
 use crate::terminal::locator::{self, Pattern};
 use logger::Logger;
 use session::{Session, TermState};
@@ -433,13 +433,13 @@ fn cells(s: &Session, x: u16, y: u16, w: u16, h: u16) -> Response {
                 out.push(json!({
                     "x": col,
                     "y": row,
-                    "char": if cell.ch.is_empty() { " ".to_string() } else { cell.ch.clone() },
+                    "char": cell.ch.as_str(),
                     "fg": color_json(cell.fg),
                     "bg": color_json(cell.bg),
-                    "bold": cell.bold,
-                    "italic": cell.italic,
-                    "underline": cell.underline,
-                    "inverse": cell.inverse,
+                    "bold": cell.has(Attrs::BOLD),
+                    "italic": cell.has(Attrs::ITALIC),
+                    "underline": cell.underline.is_some(),
+                    "inverse": cell.has(Attrs::INVERSE),
                 }));
             }
         }
@@ -447,11 +447,14 @@ fn cells(s: &Session, x: u16, y: u16, w: u16, h: u16) -> Response {
     Response::with(json!({ "cells": out }))
 }
 
-fn color_json(c: Color) -> serde_json::Value {
+/// Wire form: `"default"`, a 256-color index, or `"#rrggbb"`. Named and
+/// indexed colors both serialize to their palette index, so the split between
+/// them stays internal and the language bindings are unaffected.
+fn color_json(c: Option<Color>) -> serde_json::Value {
     match c {
-        Color::Default => json!("default"),
-        Color::Idx(i) => json!(i),
-        Color::Rgb(r, g, b) => json!(format!("#{r:02x}{g:02x}{b:02x}")),
+        None => json!("default"),
+        Some(Color::Rgb(r, g, b)) => json!(format!("#{r:02x}{g:02x}{b:02x}")),
+        Some(c) => json!(c.to_index()),
     }
 }
 
@@ -712,11 +715,7 @@ fn check_colors(
                     if not { "absent" } else { "present" },
                     expected.describe(),
                     color::describe_cell(c.cell.fg, &expected),
-                    if c.cell.ch.is_empty() {
-                        " "
-                    } else {
-                        &c.cell.ch
-                    },
+                    c.cell.ch,
                     c.x,
                     c.y
                 ));
@@ -732,11 +731,7 @@ fn check_colors(
                     if not { "absent" } else { "present" },
                     expected.describe(),
                     color::describe_cell(c.cell.bg, &expected),
-                    if c.cell.ch.is_empty() {
-                        " "
-                    } else {
-                        &c.cell.ch
-                    },
+                    c.cell.ch,
                     c.x,
                     c.y
                 ));

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -20,7 +20,7 @@ use crate::input::{keys, mouse};
 use crate::ipc;
 use crate::monitor;
 use crate::protocol::{ErrorKind, GetField, MouseAction, Request, Response};
-use crate::terminal::cell::{rows_to_strings, Attrs, Color, EmuCell, UnderlineStyle};
+use crate::terminal::cell::{rows_to_strings, Attrs, Color, EmuCell};
 use crate::terminal::locator::{self, Pattern};
 use logger::Logger;
 use session::{Session, TermState};
@@ -455,15 +455,12 @@ fn cell_json(x: u16, y: u16, cell: &EmuCell) -> serde_json::Value {
         "strike": cell.has(Attrs::STRIKE),
         "blink": cell.has(Attrs::BLINK),
         "underline": cell.underline.is_some(),
-        "underline_style": cell.underline.map(|u| match u.style {
-            UnderlineStyle::Single => "single",
-            UnderlineStyle::Double => "double",
-            UnderlineStyle::Curly => "curly",
-            UnderlineStyle::Dotted => "dotted",
-            UnderlineStyle::Dashed => "dashed",
-        }),
-        // `null` means the underline follows the text color.
-        "underline_color": cell.underline.and_then(|u| u.color).map(|c| color_json(Some(c))),
+        // Never null: an absent underline is the "none" style, and an
+        // underline that follows the text color is "default", the same
+        // sentinel `fg` and `bg` use. A client can switch on the string
+        // without a null check.
+        "underline_style": cell.underline.map_or("none", |u| u.style.name()),
+        "underline_color": color_json(cell.underline.and_then(|u| u.color)),
     })
 }
 
@@ -865,7 +862,7 @@ fn format_timeout(timeout_ms: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::terminal::cell::{NamedColor, Underline};
+    use crate::terminal::cell::{NamedColor, Underline, UnderlineStyle};
 
     /// Every attribute in the vocabulary reaches the wire, including ones the
     /// alacritty backend can never source (blink), so clients written against
@@ -903,12 +900,28 @@ mod tests {
         assert_eq!(v["underline_color"], json!("#010203"));
     }
 
+    /// The underline fields are never null, so a client can switch on the
+    /// style string and compare the color the same way it does `fg`.
     #[test]
-    fn cell_json_blank_cell_has_no_underline() {
+    fn cell_json_underline_fields_are_never_null() {
         let v = cell_json(0, 0, &EmuCell::blank());
         assert_eq!(v["underline"], json!(false));
-        assert_eq!(v["underline_style"], serde_json::Value::Null);
-        assert_eq!(v["underline_color"], serde_json::Value::Null);
+        assert_eq!(v["underline_style"], json!("none"));
+        assert_eq!(v["underline_color"], json!("default"));
         assert_eq!(v["blink"], json!(false));
+
+        // Underlined, but with no color of its own: it follows the text color,
+        // which is the same thing `fg: "default"` means.
+        let cell = EmuCell {
+            underline: Some(Underline {
+                style: UnderlineStyle::Single,
+                color: None,
+            }),
+            ..EmuCell::blank()
+        };
+        let v = cell_json(0, 0, &cell);
+        assert_eq!(v["underline"], json!(true));
+        assert_eq!(v["underline_style"], json!("single"));
+        assert_eq!(v["underline_color"], json!("default"));
     }
 }

--- a/src/daemon/session.rs
+++ b/src/daemon/session.rs
@@ -8,12 +8,17 @@ use std::time::Instant;
 
 use crate::daemon::logger::Logger;
 use crate::shell::{self, Shell};
-use crate::terminal::emu::Emu;
+use crate::terminal::alacritty::AlacrittyEmu;
+use crate::terminal::emu::Emulator;
+use crate::terminal::integration::CommandTracker;
 use crate::terminal::pty::{Pty, SpawnOptions};
 use crate::trace::recorder::Recorder;
 
 pub struct TermState {
-    pub emu: Emu,
+    pub emu: Box<dyn Emulator>,
+    /// Shell-integration state, derived from the raw PTY stream rather than
+    /// the emulator, so it is identical across backends.
+    pub tracker: CommandTracker,
     pub last_change: Instant,
     pub exited: Option<i32>,
 }
@@ -60,7 +65,8 @@ impl Session {
         };
 
         let state = Arc::new(Mutex::new(TermState {
-            emu: Emu::new(cols, rows, 5_000),
+            emu: Box::new(AlacrittyEmu::new(cols, rows, 5_000)),
+            tracker: CommandTracker::new(),
             last_change: Instant::now(),
             exited: None,
         }));
@@ -94,6 +100,7 @@ impl Session {
                         let pending = {
                             let mut st = reader_state.lock().unwrap();
                             st.emu.process(&buf[..n]);
+                            st.tracker.feed(&buf[..n]);
                             st.last_change = Instant::now();
                             st.emu.take_pending_writes()
                         };

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::terminal::cell::{Color, EmuCell};
+use crate::terminal::cell::{Attrs, Color, EmuCell, Underline, UnderlineStyle};
 
 const BORDER: &str = "\x1b[38;5;240m";
 const RESET: &str = "\x1b[0m";
@@ -80,23 +80,16 @@ fn content(out: &mut String, f: &Frame, inner_w: usize, inner_h: usize) {
         let row = f.grid.get(y);
         let mut last: Option<Style> = None;
         for x in 0..inner_w {
-            let mut cell = row
-                .and_then(|r| r.get(x))
-                .cloned()
-                .unwrap_or_else(blank_cell);
+            let mut cell = row.and_then(|r| r.get(x)).cloned().unwrap_or_default();
             if show_cursor && x as u16 == cx && y as u16 == cy {
-                cell.inverse = !cell.inverse;
+                cell.attrs.toggle(Attrs::INVERSE);
             }
             let style = Style::from(&cell);
             if last.as_ref() != Some(&style) {
                 out.push_str(&style.sgr());
                 last = Some(style);
             }
-            if cell.ch.is_empty() {
-                out.push(' ');
-            } else {
-                out.push_str(&cell.ch);
-            }
+            out.push_str(&cell.ch);
         }
         out.push_str(RESET);
         out.push_str(BORDER);
@@ -152,15 +145,10 @@ fn border_line(out: &mut String, left: char, right: char, title: &str, inner_w: 
 
 #[derive(PartialEq, Clone)]
 struct Style {
-    fg: Color,
-    bg: Color,
-    bold: bool,
-    dim: bool,
-    italic: bool,
-    underline: bool,
-    inverse: bool,
-    invisible: bool,
-    strike: bool,
+    fg: Option<Color>,
+    bg: Option<Color>,
+    underline: Option<Underline>,
+    attrs: Attrs,
 }
 
 impl Style {
@@ -168,30 +156,40 @@ impl Style {
         Style {
             fg: c.fg,
             bg: c.bg,
-            bold: c.bold,
-            dim: c.dim,
-            italic: c.italic,
             underline: c.underline,
-            inverse: c.inverse,
-            invisible: c.invisible,
-            strike: c.strike,
+            attrs: c.attrs,
         }
     }
 
     fn sgr(&self) -> String {
         let mut s = String::from("\x1b[0");
-        for (on, code) in [
-            (self.bold, "1"),
-            (self.dim, "2"),
-            (self.italic, "3"),
-            (self.underline, "4"),
-            (self.inverse, "7"),
-            (self.invisible, "8"),
-            (self.strike, "9"),
+        for (attr, code) in [
+            (Attrs::BOLD, "1"),
+            (Attrs::DIM, "2"),
+            (Attrs::ITALIC, "3"),
+            (Attrs::BLINK, "5"),
+            (Attrs::INVERSE, "7"),
+            (Attrs::INVISIBLE, "8"),
+            (Attrs::STRIKE, "9"),
         ] {
-            if on {
+            if self.attrs.contains(attr) {
                 s.push(';');
                 s.push_str(code);
+            }
+        }
+        if let Some(u) = self.underline {
+            let sub = match u.style {
+                UnderlineStyle::Single => 1,
+                UnderlineStyle::Double => 2,
+                UnderlineStyle::Curly => 3,
+                UnderlineStyle::Dotted => 4,
+                UnderlineStyle::Dashed => 5,
+            };
+            s.push_str(&format!(";4:{sub}"));
+            match u.color {
+                Some(Color::Rgb(r, g, b)) => s.push_str(&format!(";58;2::{r}:{g}:{b}")),
+                Some(c) => s.push_str(&format!(";58;5;{}", c.to_index())),
+                None => {}
             }
         }
         push_color(&mut s, self.fg, true);
@@ -201,27 +199,12 @@ impl Style {
     }
 }
 
-fn push_color(s: &mut String, color: Color, fg: bool) {
+fn push_color(s: &mut String, color: Option<Color>, fg: bool) {
     let base = if fg { 38 } else { 48 };
     match color {
-        Color::Default => {}
-        Color::Idx(i) => s.push_str(&format!(";{base};5;{i}")),
-        Color::Rgb(r, g, b) => s.push_str(&format!(";{base};2;{r};{g};{b}")),
-    }
-}
-
-fn blank_cell() -> EmuCell {
-    EmuCell {
-        ch: String::new(),
-        fg: Color::Default,
-        bg: Color::Default,
-        bold: false,
-        dim: false,
-        italic: false,
-        underline: false,
-        inverse: false,
-        invisible: false,
-        strike: false,
+        None => {}
+        Some(Color::Rgb(r, g, b)) => s.push_str(&format!(";{base};2;{r};{g};{b}")),
+        Some(c) => s.push_str(&format!(";{base};5;{}", c.to_index())),
     }
 }
 
@@ -367,8 +350,8 @@ mod tests {
 
     fn cell(ch: &str) -> EmuCell {
         EmuCell {
-            ch: ch.to_string(),
-            ..blank_cell()
+            ch: ch.into(),
+            ..EmuCell::blank()
         }
     }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::terminal::emu::{Color, EmuCell};
+use crate::terminal::cell::{Color, EmuCell};
 
 const BORDER: &str = "\x1b[38;5;240m";
 const RESET: &str = "\x1b[0m";

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::terminal::cell::{Attrs, Color, EmuCell, Underline, UnderlineStyle};
+use crate::terminal::cell::{Attrs, Color, EmuCell, UnderlineStyle};
 
 const BORDER: &str = "\x1b[38;5;240m";
 const RESET: &str = "\x1b[0m";
@@ -147,7 +147,8 @@ fn border_line(out: &mut String, left: char, right: char, title: &str, inner_w: 
 struct Style {
     fg: Option<Color>,
     bg: Option<Color>,
-    underline: Option<Underline>,
+    underline: UnderlineStyle,
+    underline_color: Option<Color>,
     attrs: Attrs,
 }
 
@@ -157,6 +158,7 @@ impl Style {
             fg: c.fg,
             bg: c.bg,
             underline: c.underline,
+            underline_color: c.underline_color,
             attrs: c.attrs,
         }
     }
@@ -177,19 +179,20 @@ impl Style {
                 s.push_str(code);
             }
         }
-        if let Some(u) = self.underline {
-            let sub = match u.style {
-                UnderlineStyle::Single => 1,
-                UnderlineStyle::Double => 2,
-                UnderlineStyle::Curly => 3,
-                UnderlineStyle::Dotted => 4,
-                UnderlineStyle::Dashed => 5,
-            };
+        let sub = match self.underline {
+            UnderlineStyle::None => 0,
+            UnderlineStyle::Single => 1,
+            UnderlineStyle::Double => 2,
+            UnderlineStyle::Curly => 3,
+            UnderlineStyle::Dotted => 4,
+            UnderlineStyle::Dashed => 5,
+        };
+        if sub != 0 {
             s.push_str(&format!(";4:{sub}"));
             // SGR 58 takes its arguments as colon-joined subparameters. Mixing
             // in a `;` would end the parameter early and the terminal would
             // read whatever follows as the underline's color instead.
-            match u.color {
+            match self.underline_color {
                 Some(Color::Rgb(r, g, b)) => s.push_str(&format!(";58:2::{r}:{g}:{b}")),
                 Some(c) => s.push_str(&format!(";58:5:{}", c.to_index())),
                 None => {}
@@ -371,28 +374,22 @@ mod tests {
             Style {
                 fg: Some(Color::Named(NamedColor::Red)),
                 bg: Some(Color::Idx(196)),
-                underline: Some(Underline {
-                    style: UnderlineStyle::Curly,
-                    color: Some(Color::Rgb(1, 2, 3)),
-                }),
+                underline: UnderlineStyle::Curly,
+                underline_color: Some(Color::Rgb(1, 2, 3)),
                 attrs: Attrs::BOLD | Attrs::ITALIC | Attrs::STRIKE,
             },
             Style {
                 fg: Some(Color::Rgb(9, 8, 7)),
                 bg: None,
-                underline: Some(Underline {
-                    style: UnderlineStyle::Dotted,
-                    color: Some(Color::Idx(33)),
-                }),
+                underline: UnderlineStyle::Dotted,
+                underline_color: Some(Color::Idx(33)),
                 attrs: Attrs::DIM,
             },
             Style {
                 fg: None,
                 bg: Some(Color::Named(NamedColor::BrightWhite)),
-                underline: Some(Underline {
-                    style: UnderlineStyle::Single,
-                    color: None,
-                }),
+                underline: UnderlineStyle::Single,
+                underline_color: None,
                 attrs: Attrs::empty(),
             },
         ];
@@ -404,11 +401,12 @@ mod tests {
             let got = Style::from(&emu.viewable_rows()[0][0]);
             assert!(
                 got == want,
-                "{:?} round-tripped to fg={:?} bg={:?} underline={:?} attrs={:?}",
+                "{:?} round-tripped to fg={:?} bg={:?} underline={:?}/{:?} attrs={:?}",
                 want.sgr(),
                 got.fg,
                 got.bg,
                 got.underline,
+                got.underline_color,
                 got.attrs,
             );
         }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -186,9 +186,12 @@ impl Style {
                 UnderlineStyle::Dashed => 5,
             };
             s.push_str(&format!(";4:{sub}"));
+            // SGR 58 takes its arguments as colon-joined subparameters. Mixing
+            // in a `;` would end the parameter early and the terminal would
+            // read whatever follows as the underline's color instead.
             match u.color {
-                Some(Color::Rgb(r, g, b)) => s.push_str(&format!(";58;2::{r}:{g}:{b}")),
-                Some(c) => s.push_str(&format!(";58;5;{}", c.to_index())),
+                Some(Color::Rgb(r, g, b)) => s.push_str(&format!(";58:2::{r}:{g}:{b}")),
+                Some(c) => s.push_str(&format!(";58:5:{}", c.to_index())),
                 None => {}
             }
         }
@@ -352,6 +355,62 @@ mod tests {
         EmuCell {
             ch: ch.into(),
             ..EmuCell::blank()
+        }
+    }
+
+    /// `sgr` writes to the viewer's real terminal, so the only honest check is
+    /// to feed it back through an emulator and see the same style come out.
+    /// A malformed escape does not fail loudly; it silently reassigns the
+    /// parameters that follow it, which is how `58` once swallowed the
+    /// foreground color.
+    #[test]
+    fn sgr_survives_a_round_trip_through_the_emulator() {
+        use crate::terminal::{alacritty::AlacrittyEmu, cell::NamedColor, emu::Emulator};
+
+        let styles = [
+            Style {
+                fg: Some(Color::Named(NamedColor::Red)),
+                bg: Some(Color::Idx(196)),
+                underline: Some(Underline {
+                    style: UnderlineStyle::Curly,
+                    color: Some(Color::Rgb(1, 2, 3)),
+                }),
+                attrs: Attrs::BOLD | Attrs::ITALIC | Attrs::STRIKE,
+            },
+            Style {
+                fg: Some(Color::Rgb(9, 8, 7)),
+                bg: None,
+                underline: Some(Underline {
+                    style: UnderlineStyle::Dotted,
+                    color: Some(Color::Idx(33)),
+                }),
+                attrs: Attrs::DIM,
+            },
+            Style {
+                fg: None,
+                bg: Some(Color::Named(NamedColor::BrightWhite)),
+                underline: Some(Underline {
+                    style: UnderlineStyle::Single,
+                    color: None,
+                }),
+                attrs: Attrs::empty(),
+            },
+        ];
+
+        for want in styles {
+            let mut emu = AlacrittyEmu::new(10, 2, 0);
+            emu.process(want.sgr().as_bytes());
+            emu.process(b"x");
+            let got = Style::from(&emu.viewable_rows()[0][0]);
+            assert!(
+                got == want,
+                "{:?} round-tripped to fg={:?} bg={:?} underline={:?} attrs={:?}",
+                want.sgr(),
+                got.fg,
+                got.bg,
+                got.underline,
+                got.attrs,
+            );
         }
     }
 

--- a/src/render/nerd_font.rs
+++ b/src/render/nerd_font.rs
@@ -208,20 +208,10 @@ fn is_powerline_separator(c: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::terminal::cell::Color;
-
     fn cell(ch: &str) -> EmuCell {
         EmuCell {
-            ch: ch.to_string(),
-            fg: Color::Default,
-            bg: Color::Default,
-            bold: false,
-            dim: false,
-            italic: false,
-            underline: false,
-            inverse: false,
-            invisible: false,
-            strike: false,
+            ch: ch.into(),
+            ..EmuCell::blank()
         }
     }
 

--- a/src/render/nerd_font.rs
+++ b/src/render/nerd_font.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 
 use ttf_parser::{Face, OutlineBuilder};
 
-use crate::terminal::emu::EmuCell;
+use crate::terminal::cell::EmuCell;
 
 // Nerd Fonts Symbols v3.4.0 is MIT-licensed; see the adjacent LICENSE.
 const FONT_DATA: &[u8] = include_bytes!(concat!(
@@ -208,7 +208,7 @@ fn is_powerline_separator(c: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::terminal::emu::Color;
+    use crate::terminal::cell::Color;
 
     fn cell(ch: &str) -> EmuCell {
         EmuCell {

--- a/src/render/svg.rs
+++ b/src/render/svg.rs
@@ -11,7 +11,7 @@
 use std::fmt::Write;
 
 use super::nerd_font::NerdFont;
-use crate::terminal::emu::{Color, EmuCell};
+use crate::terminal::cell::{Color, EmuCell};
 
 const CELL_W: f32 = 10.0;
 const CELL_H: f32 = 21.0;

--- a/src/render/svg.rs
+++ b/src/render/svg.rs
@@ -11,7 +11,7 @@
 use std::fmt::Write;
 
 use super::nerd_font::NerdFont;
-use crate::terminal::cell::{Color, EmuCell};
+use crate::terminal::cell::{Attrs, Color, EmuCell};
 
 const CELL_W: f32 = 10.0;
 const CELL_H: f32 = 21.0;
@@ -58,18 +58,18 @@ impl Default for Theme {
 }
 
 impl Theme {
-    fn resolve(&self, color: Color, is_fg: bool) -> (u8, u8, u8) {
+    fn resolve(&self, color: Option<Color>, is_fg: bool) -> (u8, u8, u8) {
         match color {
-            Color::Default => {
+            None => {
                 if is_fg {
                     self.default_fg
                 } else {
                     self.default_bg
                 }
             }
-            Color::Idx(i) if i < 16 => self.palette[i as usize],
-            Color::Idx(i) => crate::assert::color::ansi256_to_rgb(i),
-            Color::Rgb(r, g, b) => (r, g, b),
+            Some(Color::Named(n)) => self.palette[n.index() as usize],
+            Some(Color::Idx(i)) => crate::assert::color::ansi256_to_rgb(i),
+            Some(Color::Rgb(r, g, b)) => (r, g, b),
         }
     }
 }
@@ -83,18 +83,7 @@ fn dim((r, g, b): (u8, u8, u8)) -> (u8, u8, u8) {
     (s(r), s(g), s(b))
 }
 
-static BLANK: EmuCell = EmuCell {
-    ch: String::new(),
-    fg: Color::Default,
-    bg: Color::Default,
-    bold: false,
-    dim: false,
-    italic: false,
-    underline: false,
-    inverse: false,
-    invisible: false,
-    strike: false,
-};
+static BLANK: EmuCell = EmuCell::blank();
 
 fn cell_at(row: &[EmuCell], x: usize) -> &EmuCell {
     row.get(x).unwrap_or(&BLANK)
@@ -104,7 +93,7 @@ fn cell_at(row: &[EmuCell], x: usize) -> &EmuCell {
 fn bg_of(cell: &EmuCell, theme: &Theme) -> (u8, u8, u8) {
     let bg = theme.resolve(cell.bg, false);
     let fg = theme.resolve(cell.fg, true);
-    if cell.inverse {
+    if cell.has(Attrs::INVERSE) {
         fg
     } else {
         bg
@@ -124,19 +113,19 @@ struct Style {
 fn style_of(cell: &EmuCell, theme: &Theme) -> Style {
     let mut fg = theme.resolve(cell.fg, true);
     let bg = theme.resolve(cell.bg, false);
-    if cell.inverse {
+    if cell.has(Attrs::INVERSE) {
         fg = bg;
     }
-    if cell.dim {
+    if cell.has(Attrs::DIM) {
         fg = dim(fg);
     }
     Style {
         fg,
-        bold: cell.bold,
-        italic: cell.italic,
-        underline: cell.underline,
-        strike: cell.strike,
-        invisible: cell.invisible,
+        bold: cell.has(Attrs::BOLD),
+        italic: cell.has(Attrs::ITALIC),
+        underline: cell.underline.is_some(),
+        strike: cell.has(Attrs::STRIKE),
+        invisible: cell.has(Attrs::INVISIBLE),
     }
 }
 
@@ -156,12 +145,7 @@ fn escape(s: &str) -> String {
 fn run_text(row: &[EmuCell], start: usize, end: usize) -> String {
     let mut text = String::with_capacity(end - start);
     for i in start..end {
-        let ch = &cell_at(row, i).ch;
-        if ch.is_empty() {
-            text.push(' ');
-        } else {
-            text.push_str(ch);
-        }
+        text.push_str(&cell_at(row, i).ch);
     }
     text
 }
@@ -282,19 +266,20 @@ pub fn render_svg(rows: &[Vec<EmuCell>], cols: u16) -> String {
 mod tests {
     use super::*;
 
-    fn cell(ch: &str, fg: Color, bg: Color) -> EmuCell {
-        let mut c = BLANK.clone();
-        c.ch = ch.to_string();
-        c.fg = fg;
-        c.bg = bg;
-        c
+    fn cell(ch: &str, fg: Option<Color>, bg: Option<Color>) -> EmuCell {
+        EmuCell {
+            ch: ch.into(),
+            fg,
+            bg,
+            ..EmuCell::blank()
+        }
     }
 
     #[test]
     fn emits_valid_svg_with_text_and_color() {
         let rows = vec![vec![
-            cell("h", Color::Idx(1), Color::Default),
-            cell("i", Color::Idx(1), Color::Default),
+            cell("h", Some(Color::from_index(1)), None),
+            cell("i", Some(Color::from_index(1)), None),
         ]];
         let svg = render_svg(&rows, 2);
         assert!(svg.starts_with("<svg"));
@@ -308,7 +293,7 @@ mod tests {
 
     #[test]
     fn emits_window_chrome() {
-        let svg = render_svg(&[vec![cell(" ", Color::Default, Color::Default)]], 1);
+        let svg = render_svg(&[vec![cell(" ", None, None)]], 1);
         assert!(svg.contains("<circle"));
         assert!(svg.contains("#ff5f56"));
         assert!(svg.contains("#ffbd2e"));
@@ -317,14 +302,14 @@ mod tests {
 
     #[test]
     fn centers_the_text_font_box_in_each_cell() {
-        let svg = render_svg(&[vec![cell("x", Color::Default, Color::Default)]], 1);
+        let svg = render_svg(&[vec![cell("x", None, None)]], 1);
         let expected_baseline = HEADER_H + FONT_BASELINE;
         assert!(svg.contains(&format!(r#"y="{expected_baseline:.2}""#)));
     }
 
     #[test]
     fn escapes_markup_characters() {
-        let rows = vec![vec![cell("<", Color::Default, Color::Default)]];
+        let rows = vec![vec![cell("<", None, None)]];
         let svg = render_svg(&rows, 1);
         assert!(svg.contains("&lt;"));
         assert!(!svg.contains("><</text>"));
@@ -332,7 +317,7 @@ mod tests {
 
     #[test]
     fn background_run_emitted_for_non_default_bg() {
-        let rows = vec![vec![cell(" ", Color::Default, Color::Idx(4))]];
+        let rows = vec![vec![cell(" ", None, Some(Color::from_index(4)))]];
         let svg = render_svg(&rows, 1);
         assert!(svg.contains(&hex((113, 190, 242))));
     }
@@ -341,9 +326,9 @@ mod tests {
     fn embeds_nerd_font_glyphs_as_vector_paths() {
         let glyph = "\u{f115}";
         let rows = vec![vec![
-            cell("a", Color::Default, Color::Default),
-            cell(glyph, Color::Default, Color::Default),
-            cell("b", Color::Default, Color::Default),
+            cell("a", None, None),
+            cell(glyph, None, None),
+            cell("b", None, None),
         ]];
         let svg = render_svg(&rows, 3);
 
@@ -357,13 +342,7 @@ mod tests {
     #[test]
     fn defines_repeated_nerd_font_glyph_once() {
         let glyph = "\u{f115}";
-        let svg = render_svg(
-            &[vec![
-                cell(glyph, Color::Default, Color::Default),
-                cell(glyph, Color::Default, Color::Default),
-            ]],
-            2,
-        );
+        let svg = render_svg(&[vec![cell(glyph, None, None), cell(glyph, None, None)]], 2);
 
         assert_eq!(svg.matches(r#"<path id="nf-f115""#).count(), 1);
         assert_eq!(svg.matches(r##"<use href="#nf-f115""##).count(), 2);
@@ -372,7 +351,7 @@ mod tests {
     #[test]
     fn leaves_unknown_private_use_glyphs_as_text() {
         let glyph = "\u{10fffd}";
-        let svg = render_svg(&[vec![cell(glyph, Color::Default, Color::Default)]], 1);
+        let svg = render_svg(&[vec![cell(glyph, None, None)]], 1);
 
         assert!(svg.contains(glyph));
         assert!(!svg.contains("<defs>"));

--- a/src/render/svg.rs
+++ b/src/render/svg.rs
@@ -123,7 +123,7 @@ fn style_of(cell: &EmuCell, theme: &Theme) -> Style {
         fg,
         bold: cell.has(Attrs::BOLD),
         italic: cell.has(Attrs::ITALIC),
-        underline: cell.underline.is_some(),
+        underline: cell.underline.is_underlined(),
         strike: cell.has(Attrs::STRIKE),
         invisible: cell.has(Attrs::INVISIBLE),
     }

--- a/src/terminal/alacritty.rs
+++ b/src/terminal/alacritty.rs
@@ -1,0 +1,158 @@
+//! [`Emulator`] backend built on `alacritty_terminal`. Translates the
+//! alacritty grid into shell-use's neutral cell vocabulary, plus a capture
+//! proxy that queues the terminal's replies so the reader can forward them
+//! back to the PTY.
+
+use std::sync::{Arc, Mutex};
+
+use alacritty_terminal::event::{Event, EventListener};
+use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::index::{Column, Line};
+use alacritty_terminal::term::cell::Flags as AlacFlags;
+use alacritty_terminal::term::test::TermSize;
+use alacritty_terminal::term::{Config as AlacConfig, Term};
+use alacritty_terminal::vte::ansi;
+
+use crate::terminal::cell::{Color, EmuCell};
+use crate::terminal::emu::Emulator;
+
+fn color_from_alac(c: ansi::Color) -> Color {
+    match c {
+        ansi::Color::Named(named) => match named {
+            ansi::NamedColor::Foreground | ansi::NamedColor::Background => Color::Default,
+            other => Color::Idx(other as u8),
+        },
+        ansi::Color::Spec(rgb) => Color::Rgb(rgb.r, rgb.g, rgb.b),
+        ansi::Color::Indexed(i) => Color::Idx(i),
+    }
+}
+
+fn cell_from_alac(c: &alacritty_terminal::term::cell::Cell) -> EmuCell {
+    let flags = c.flags;
+    let spacer = flags.contains(AlacFlags::WIDE_CHAR_SPACER)
+        || flags.contains(AlacFlags::LEADING_WIDE_CHAR_SPACER);
+    let ch = if spacer || (c.c == ' ' && !flags.contains(AlacFlags::WIDE_CHAR)) {
+        String::new()
+    } else {
+        c.c.to_string()
+    };
+    EmuCell {
+        ch,
+        fg: color_from_alac(c.fg),
+        bg: color_from_alac(c.bg),
+        bold: flags.contains(AlacFlags::BOLD),
+        dim: flags.contains(AlacFlags::DIM),
+        italic: flags.contains(AlacFlags::ITALIC),
+        underline: flags.intersects(
+            AlacFlags::UNDERLINE
+                | AlacFlags::DOUBLE_UNDERLINE
+                | AlacFlags::DOTTED_UNDERLINE
+                | AlacFlags::DASHED_UNDERLINE
+                | AlacFlags::UNDERCURL,
+        ),
+        inverse: flags.contains(AlacFlags::INVERSE),
+        invisible: flags.contains(AlacFlags::HIDDEN),
+        strike: flags.contains(AlacFlags::STRIKEOUT),
+    }
+}
+
+#[derive(Default, Clone)]
+struct CaptureProxy {
+    pending: Arc<Mutex<Vec<u8>>>,
+}
+
+impl EventListener for CaptureProxy {
+    fn send_event(&self, ev: Event) {
+        if let Event::PtyWrite(bytes) = ev {
+            if let Ok(mut buf) = self.pending.lock() {
+                buf.extend_from_slice(bytes.as_bytes());
+            }
+        }
+    }
+}
+
+pub struct AlacrittyEmu {
+    term: Term<CaptureProxy>,
+    processor: ansi::Processor,
+    cols: u16,
+    rows: u16,
+    pending: Arc<Mutex<Vec<u8>>>,
+}
+
+impl AlacrittyEmu {
+    pub fn new(cols: u16, rows: u16, scrollback: usize) -> Self {
+        let size = TermSize::new(cols as usize, rows as usize);
+        let config = AlacConfig {
+            scrolling_history: scrollback,
+            ..Default::default()
+        };
+        let pending: Arc<Mutex<Vec<u8>>> = Arc::default();
+        let proxy = CaptureProxy {
+            pending: pending.clone(),
+        };
+        AlacrittyEmu {
+            term: Term::new(config, &size, proxy),
+            processor: ansi::Processor::new(),
+            cols,
+            rows,
+            pending,
+        }
+    }
+
+    fn rows_in_range(&self, start: i32, end: i32) -> Vec<Vec<EmuCell>> {
+        let grid = self.term.grid();
+        let mut out = Vec::with_capacity((end - start).max(0) as usize);
+        for line in start..end {
+            let mut row = Vec::with_capacity(self.cols as usize);
+            for col in 0..self.cols as usize {
+                let cell = &grid[Line(line)][Column(col)];
+                row.push(cell_from_alac(cell));
+            }
+            out.push(row);
+        }
+        out
+    }
+}
+
+impl Emulator for AlacrittyEmu {
+    fn process(&mut self, bytes: &[u8]) {
+        self.processor.advance(&mut self.term, bytes);
+    }
+
+    fn take_pending_writes(&mut self) -> Vec<u8> {
+        match self.pending.lock() {
+            Ok(mut buf) => std::mem::take(&mut *buf),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn resize(&mut self, cols: u16, rows: u16) {
+        self.term
+            .resize(TermSize::new(cols as usize, rows as usize));
+        self.cols = cols;
+        self.rows = rows;
+    }
+
+    fn size(&self) -> (u16, u16) {
+        (self.cols, self.rows)
+    }
+
+    fn cursor(&self) -> (u16, u16) {
+        let p = self.term.grid().cursor.point;
+        let y = p.line.0.max(0).min(self.rows as i32 - 1) as u16;
+        let x = (p.column.0 as u16).min(self.cols.saturating_sub(1));
+        (x, y)
+    }
+
+    fn viewable_rows(&self) -> Vec<Vec<EmuCell>> {
+        self.rows_in_range(0, self.rows as i32)
+    }
+
+    fn full_rows(&self) -> Vec<Vec<EmuCell>> {
+        let grid = self.term.grid();
+        let total = grid.total_lines() as i32;
+        let screen = grid.screen_lines() as i32;
+        let history = (total - screen).max(0);
+        self.rows_in_range(-history, screen)
+    }
+}

--- a/src/terminal/alacritty.rs
+++ b/src/terminal/alacritty.rs
@@ -13,46 +13,100 @@ use alacritty_terminal::term::test::TermSize;
 use alacritty_terminal::term::{Config as AlacConfig, Term};
 use alacritty_terminal::vte::ansi;
 
-use crate::terminal::cell::{Color, EmuCell};
+use compact_str::CompactString;
+
+use crate::terminal::cell::{Attrs, Color, EmuCell, Underline, UnderlineStyle, CONTINUATION};
 use crate::terminal::emu::Emulator;
 
-fn color_from_alac(c: ansi::Color) -> Color {
+/// Alacritty's palette colors arrive either as a `Named` variant or an index;
+/// both funnel through [`Color::from_index`] so a given slot always yields the
+/// same value. `Foreground`/`Background` are the terminal defaults, and every
+/// other `NamedColor` (`Cursor`, the `Dim*` and `Bright*` aliases) is a UI role
+/// with no cell representation, so it falls back to the default too.
+fn color_from_alac(c: ansi::Color) -> Option<Color> {
     match c {
         ansi::Color::Named(named) => match named {
-            ansi::NamedColor::Foreground | ansi::NamedColor::Background => Color::Default,
-            other => Color::Idx(other as u8),
+            ansi::NamedColor::Black
+            | ansi::NamedColor::Red
+            | ansi::NamedColor::Green
+            | ansi::NamedColor::Yellow
+            | ansi::NamedColor::Blue
+            | ansi::NamedColor::Magenta
+            | ansi::NamedColor::Cyan
+            | ansi::NamedColor::White
+            | ansi::NamedColor::BrightBlack
+            | ansi::NamedColor::BrightRed
+            | ansi::NamedColor::BrightGreen
+            | ansi::NamedColor::BrightYellow
+            | ansi::NamedColor::BrightBlue
+            | ansi::NamedColor::BrightMagenta
+            | ansi::NamedColor::BrightCyan
+            | ansi::NamedColor::BrightWhite => Some(Color::from_index(named as u8)),
+            _ => None,
         },
-        ansi::Color::Spec(rgb) => Color::Rgb(rgb.r, rgb.g, rgb.b),
-        ansi::Color::Indexed(i) => Color::Idx(i),
+        ansi::Color::Spec(rgb) => Some(Color::Rgb(rgb.r, rgb.g, rgb.b)),
+        ansi::Color::Indexed(i) => Some(Color::from_index(i)),
     }
+}
+
+fn underline_from_alac(c: &alacritty_terminal::term::cell::Cell) -> Option<Underline> {
+    let flags = c.flags;
+    // Ordered widest-to-narrowest: alacritty clears the other underline bits on
+    // each SGR, so at most one is ever set.
+    let style = if flags.contains(AlacFlags::DOUBLE_UNDERLINE) {
+        UnderlineStyle::Double
+    } else if flags.contains(AlacFlags::UNDERCURL) {
+        UnderlineStyle::Curly
+    } else if flags.contains(AlacFlags::DOTTED_UNDERLINE) {
+        UnderlineStyle::Dotted
+    } else if flags.contains(AlacFlags::DASHED_UNDERLINE) {
+        UnderlineStyle::Dashed
+    } else if flags.contains(AlacFlags::UNDERLINE) {
+        UnderlineStyle::Single
+    } else {
+        return None;
+    };
+    Some(Underline {
+        style,
+        color: c.underline_color().and_then(color_from_alac),
+    })
 }
 
 fn cell_from_alac(c: &alacritty_terminal::term::cell::Cell) -> EmuCell {
     let flags = c.flags;
     let spacer = flags.contains(AlacFlags::WIDE_CHAR_SPACER)
         || flags.contains(AlacFlags::LEADING_WIDE_CHAR_SPACER);
-    let ch = if spacer || (c.c == ' ' && !flags.contains(AlacFlags::WIDE_CHAR)) {
-        String::new()
+    let ch = if spacer {
+        CompactString::const_new(CONTINUATION)
     } else {
-        c.c.to_string()
+        let mut s = CompactString::from(c.c.to_string());
+        for zw in c.zerowidth().unwrap_or(&[]) {
+            s.push(*zw);
+        }
+        s
     };
+
+    let mut attrs = Attrs::empty();
+    for (flag, attr) in [
+        (AlacFlags::BOLD, Attrs::BOLD),
+        (AlacFlags::DIM, Attrs::DIM),
+        (AlacFlags::ITALIC, Attrs::ITALIC),
+        (AlacFlags::INVERSE, Attrs::INVERSE),
+        (AlacFlags::HIDDEN, Attrs::INVISIBLE),
+        (AlacFlags::STRIKEOUT, Attrs::STRIKE),
+    ] {
+        attrs.set(attr, flags.contains(flag));
+    }
+    // ponytail: no Attrs::BLINK here. alacritty_terminal parses SGR 5/6/25 but
+    // drops them (`Flags` has no blink bit), so this backend can never report
+    // it. Set it when a backend that tracks blink lands.
+
     EmuCell {
         ch,
         fg: color_from_alac(c.fg),
         bg: color_from_alac(c.bg),
-        bold: flags.contains(AlacFlags::BOLD),
-        dim: flags.contains(AlacFlags::DIM),
-        italic: flags.contains(AlacFlags::ITALIC),
-        underline: flags.intersects(
-            AlacFlags::UNDERLINE
-                | AlacFlags::DOUBLE_UNDERLINE
-                | AlacFlags::DOTTED_UNDERLINE
-                | AlacFlags::DASHED_UNDERLINE
-                | AlacFlags::UNDERCURL,
-        ),
-        inverse: flags.contains(AlacFlags::INVERSE),
-        invisible: flags.contains(AlacFlags::HIDDEN),
-        strike: flags.contains(AlacFlags::STRIKEOUT),
+        underline: underline_from_alac(c),
+        attrs,
     }
 }
 

--- a/src/terminal/alacritty.rs
+++ b/src/terminal/alacritty.rs
@@ -97,9 +97,10 @@ fn cell_from_alac(c: &alacritty_terminal::term::cell::Cell) -> EmuCell {
     ] {
         attrs.set(attr, flags.contains(flag));
     }
-    // ponytail: no Attrs::BLINK here. alacritty_terminal parses SGR 5/6/25 but
-    // drops them (`Flags` has no blink bit), so this backend can never report
-    // it. Set it when a backend that tracks blink lands.
+    // `Attrs::BLINK` stays clear: alacritty_terminal parses SGR 5/6/25 and then
+    // discards them, its `Flags` has no blink bit, so this backend has nothing
+    // to read. The attribute is still part of the vocabulary because ghostty
+    // (`Style.Flags.blink`) and xterm.js (`FgFlags.BLINK`) both track it.
 
     EmuCell {
         ch,

--- a/src/terminal/alacritty.rs
+++ b/src/terminal/alacritty.rs
@@ -13,7 +13,7 @@ use alacritty_terminal::term::test::TermSize;
 use alacritty_terminal::term::{Config as AlacConfig, Term};
 use alacritty_terminal::vte::ansi;
 
-use compact_str::CompactString;
+use compact_str::{CompactString, ToCompactString};
 
 use crate::terminal::cell::{Attrs, Color, EmuCell, Underline, UnderlineStyle, CONTINUATION};
 use crate::terminal::emu::Emulator;
@@ -74,12 +74,16 @@ fn underline_from_alac(c: &alacritty_terminal::term::cell::Cell) -> Option<Under
 
 fn cell_from_alac(c: &alacritty_terminal::term::cell::Cell) -> EmuCell {
     let flags = c.flags;
-    let spacer = flags.contains(AlacFlags::WIDE_CHAR_SPACER)
-        || flags.contains(AlacFlags::LEADING_WIDE_CHAR_SPACER);
-    let ch = if spacer {
+    // Only WIDE_CHAR_SPACER is a continuation: it is the second column of a
+    // wide char on this row. LEADING_WIDE_CHAR_SPACER is the opposite, a filler
+    // in the last column when a wide char did not fit and wrapped to the next
+    // row, so it owns its column and has to render as a blank.
+    let ch = if flags.contains(AlacFlags::WIDE_CHAR_SPACER) {
         CompactString::const_new(CONTINUATION)
+    } else if flags.contains(AlacFlags::LEADING_WIDE_CHAR_SPACER) {
+        CompactString::const_new(" ")
     } else {
-        let mut s = CompactString::from(c.c.to_string());
+        let mut s = c.c.to_compact_string();
         for zw in c.zerowidth().unwrap_or(&[]) {
             s.push(*zw);
         }

--- a/src/terminal/alacritty.rs
+++ b/src/terminal/alacritty.rs
@@ -156,3 +156,10 @@ impl Emulator for AlacrittyEmu {
         self.rows_in_range(-history, screen)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    crate::emulator_conformance_tests!(|c, r, s| Box::new(AlacrittyEmu::new(c, r, s)));
+}

--- a/src/terminal/alacritty.rs
+++ b/src/terminal/alacritty.rs
@@ -15,7 +15,7 @@ use alacritty_terminal::vte::ansi;
 
 use compact_str::{CompactString, ToCompactString};
 
-use crate::terminal::cell::{Attrs, Color, EmuCell, Underline, UnderlineStyle, CONTINUATION};
+use crate::terminal::cell::{Attrs, Color, EmuCell, UnderlineStyle, CONTINUATION};
 use crate::terminal::emu::Emulator;
 
 /// Alacritty's palette colors arrive either as a `Named` variant or an index;
@@ -49,11 +49,11 @@ fn color_from_alac(c: ansi::Color) -> Option<Color> {
     }
 }
 
-fn underline_from_alac(c: &alacritty_terminal::term::cell::Cell) -> Option<Underline> {
+fn underline_from_alac(c: &alacritty_terminal::term::cell::Cell) -> UnderlineStyle {
     let flags = c.flags;
     // Ordered widest-to-narrowest: alacritty clears the other underline bits on
     // each SGR, so at most one is ever set.
-    let style = if flags.contains(AlacFlags::DOUBLE_UNDERLINE) {
+    if flags.contains(AlacFlags::DOUBLE_UNDERLINE) {
         UnderlineStyle::Double
     } else if flags.contains(AlacFlags::UNDERCURL) {
         UnderlineStyle::Curly
@@ -64,12 +64,8 @@ fn underline_from_alac(c: &alacritty_terminal::term::cell::Cell) -> Option<Under
     } else if flags.contains(AlacFlags::UNDERLINE) {
         UnderlineStyle::Single
     } else {
-        return None;
-    };
-    Some(Underline {
-        style,
-        color: c.underline_color().and_then(color_from_alac),
-    })
+        UnderlineStyle::None
+    }
 }
 
 fn cell_from_alac(c: &alacritty_terminal::term::cell::Cell) -> EmuCell {
@@ -111,6 +107,7 @@ fn cell_from_alac(c: &alacritty_terminal::term::cell::Cell) -> EmuCell {
         fg: color_from_alac(c.fg),
         bg: color_from_alac(c.bg),
         underline: underline_from_alac(c),
+        underline_color: c.underline_color().and_then(color_from_alac),
         attrs,
     }
 }

--- a/src/terminal/cell.rs
+++ b/src/terminal/cell.rs
@@ -104,8 +104,17 @@ impl Color {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// The shape of a cell's underline.
+///
+/// [`UnderlineStyle::None`] is a value, not an absence: it is the shape an
+/// un-underlined cell has. Wrapping this in an `Option` would give two ways to
+/// spell "not underlined" and force every reader through a `map` to reach the
+/// shape, which is why the style and its color sit flat on the cell rather
+/// than inside a nested struct.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum UnderlineStyle {
+    #[default]
+    None,
     Single,
     Double,
     Curly,
@@ -114,9 +123,15 @@ pub enum UnderlineStyle {
 }
 
 impl UnderlineStyle {
+    /// Is the cell underlined at all?
+    pub const fn is_underlined(self) -> bool {
+        !matches!(self, UnderlineStyle::None)
+    }
+
     /// The name this style goes by on the wire.
     pub const fn name(self) -> &'static str {
         match self {
+            UnderlineStyle::None => "none",
             UnderlineStyle::Single => "single",
             UnderlineStyle::Double => "double",
             UnderlineStyle::Curly => "curly",
@@ -124,13 +139,6 @@ impl UnderlineStyle {
             UnderlineStyle::Dashed => "dashed",
         }
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Underline {
-    pub style: UnderlineStyle,
-    /// `None` means the underline takes the cell's foreground color.
-    pub color: Option<Color>,
 }
 
 bitflags! {
@@ -161,8 +169,11 @@ pub struct EmuCell {
     pub fg: Option<Color>,
     /// `None` means the terminal's default background.
     pub bg: Option<Color>,
-    /// `None` means not underlined.
-    pub underline: Option<Underline>,
+    pub underline: UnderlineStyle,
+    /// `None` means the underline takes the cell's foreground color. Carried
+    /// even when there is no underline, the same way `fg` outlives the
+    /// grapheme it colors.
+    pub underline_color: Option<Color>,
     pub attrs: Attrs,
 }
 
@@ -173,7 +184,8 @@ impl EmuCell {
             ch: CompactString::const_new(" "),
             fg: None,
             bg: None,
-            underline: None,
+            underline: UnderlineStyle::None,
+            underline_color: None,
             attrs: Attrs::empty(),
         }
     }

--- a/src/terminal/cell.rs
+++ b/src/terminal/cell.rs
@@ -5,52 +5,211 @@
 //! behind [`crate::terminal::emu::Emulator`] is invisible to them. Nothing in
 //! this module may depend on a specific emulator crate.
 
+use bitflags::bitflags;
+use compact_str::CompactString;
+
+/// The 16 themeable palette slots (ANSI 0-15).
+///
+/// Split out from [`Color::Idx`] by *numeric range*, not by how the escape
+/// sequence spelled it: backends disagree on spelling (alacritty has a `Named`
+/// variant, libghostty and xterm.js only carry palette indices) but all agree
+/// that 0-15 are the slots a theme may override.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum NamedColor {
+    Black = 0,
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Magenta,
+    Cyan,
+    White,
+    BrightBlack,
+    BrightRed,
+    BrightGreen,
+    BrightYellow,
+    BrightBlue,
+    BrightMagenta,
+    BrightCyan,
+    BrightWhite,
+}
+
+impl NamedColor {
+    pub const ALL: [NamedColor; 16] = [
+        NamedColor::Black,
+        NamedColor::Red,
+        NamedColor::Green,
+        NamedColor::Yellow,
+        NamedColor::Blue,
+        NamedColor::Magenta,
+        NamedColor::Cyan,
+        NamedColor::White,
+        NamedColor::BrightBlack,
+        NamedColor::BrightRed,
+        NamedColor::BrightGreen,
+        NamedColor::BrightYellow,
+        NamedColor::BrightBlue,
+        NamedColor::BrightMagenta,
+        NamedColor::BrightCyan,
+        NamedColor::BrightWhite,
+    ];
+
+    /// The palette slot this name occupies (0-15).
+    pub fn index(self) -> u8 {
+        self as u8
+    }
+
+    /// The name for a palette slot, or `None` outside 0-15.
+    pub fn from_index(i: u8) -> Option<Self> {
+        Self::ALL.get(i as usize).copied()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Color {
-    Default,
+    /// A themeable palette slot, ANSI 0-15.
+    Named(NamedColor),
+    /// A fixed 256-color palette index, 16-255.
     Idx(u8),
     Rgb(u8, u8, u8),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EmuCell {
-    /// Empty string means a blank cell (rendered as a space).
-    pub ch: String,
-    pub fg: Color,
-    pub bg: Color,
-    pub bold: bool,
-    pub dim: bool,
-    pub italic: bool,
-    pub underline: bool,
-    pub inverse: bool,
-    pub invisible: bool,
-    pub strike: bool,
-}
+impl Color {
+    /// Build from a 256-color index, routing 0-15 to [`Color::Named`] so the
+    /// same index yields the same value no matter which backend produced it.
+    pub fn from_index(i: u8) -> Self {
+        match NamedColor::from_index(i) {
+            Some(named) => Color::Named(named),
+            None => Color::Idx(i),
+        }
+    }
 
-impl Default for EmuCell {
-    fn default() -> Self {
-        EmuCell {
-            ch: String::new(),
-            fg: Color::Default,
-            bg: Color::Default,
-            bold: false,
-            dim: false,
-            italic: false,
-            underline: false,
-            inverse: false,
-            invisible: false,
-            strike: false,
+    /// The 256-color index for this color, approximating RGB.
+    pub fn to_index(self) -> u8 {
+        match self {
+            Color::Named(n) => n.index(),
+            Color::Idx(i) => i,
+            Color::Rgb(r, g, b) => crate::assert::color::rgb_to_ansi256(r, g, b),
         }
     }
 }
 
-/// Join a grid of cells into one string per row (blank cells → spaces).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnderlineStyle {
+    Single,
+    Double,
+    Curly,
+    Dotted,
+    Dashed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Underline {
+    pub style: UnderlineStyle,
+    /// `None` means the underline takes the cell's foreground color.
+    pub color: Option<Color>,
+}
+
+bitflags! {
+    /// Boolean SGR attributes, one bit each: the render and monitor loops copy
+    /// and compare a cell's style per column, so keeping it to a single byte
+    /// keeps those comparisons to a single integer compare.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+    pub struct Attrs: u8 {
+        const BOLD      = 1 << 0;
+        const DIM       = 1 << 1;
+        const ITALIC    = 1 << 2;
+        const INVERSE   = 1 << 3;
+        const INVISIBLE = 1 << 4;
+        const STRIKE    = 1 << 5;
+        const BLINK     = 1 << 6;
+    }
+}
+
+/// The grapheme stored in the cell that follows a double-width character.
+pub const CONTINUATION: &str = "";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmuCell {
+    /// The cell's grapheme. A blank cell holds `" "`; [`CONTINUATION`] (the
+    /// empty string) is reserved for the cell trailing a double-width char.
+    pub ch: CompactString,
+    /// `None` means the terminal's default foreground.
+    pub fg: Option<Color>,
+    /// `None` means the terminal's default background.
+    pub bg: Option<Color>,
+    /// `None` means not underlined.
+    pub underline: Option<Underline>,
+    pub attrs: Attrs,
+}
+
+impl EmuCell {
+    /// A blank, unstyled cell.
+    pub const fn blank() -> Self {
+        EmuCell {
+            ch: CompactString::const_new(" "),
+            fg: None,
+            bg: None,
+            underline: None,
+            attrs: Attrs::empty(),
+        }
+    }
+
+    pub fn has(&self, attr: Attrs) -> bool {
+        self.attrs.contains(attr)
+    }
+}
+
+impl Default for EmuCell {
+    fn default() -> Self {
+        EmuCell::blank()
+    }
+}
+
+/// Join a grid of cells into one string per row.
+///
+/// Continuation cells contribute nothing: a double-width character already
+/// carries both its columns, so emitting a filler for the second one would
+/// widen the row by one and shift every column after it.
 pub fn rows_to_strings(rows: &[Vec<EmuCell>]) -> Vec<String> {
     rows.iter()
-        .map(|row| {
-            row.iter()
-                .map(|c| if c.ch.is_empty() { " " } else { c.ch.as_str() })
-                .collect::<String>()
-        })
+        .map(|row| row.iter().map(|c| c.ch.as_str()).collect::<String>())
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cell(s: &str) -> EmuCell {
+        EmuCell {
+            ch: CompactString::from(s),
+            ..EmuCell::blank()
+        }
+    }
+
+    #[test]
+    fn index_splits_named_from_palette() {
+        assert_eq!(Color::from_index(0), Color::Named(NamedColor::Black));
+        assert_eq!(Color::from_index(9), Color::Named(NamedColor::BrightRed));
+        assert_eq!(Color::from_index(15), Color::Named(NamedColor::BrightWhite));
+        assert_eq!(Color::from_index(16), Color::Idx(16));
+        assert_eq!(Color::from_index(255), Color::Idx(255));
+        for i in 0..=255u8 {
+            assert_eq!(Color::from_index(i).to_index(), i, "roundtrip {i}");
+        }
+    }
+
+    #[test]
+    fn continuation_cells_do_not_widen_a_row() {
+        let rows = vec![vec![cell("你"), cell(CONTINUATION), cell("a"), cell(" ")]];
+        assert_eq!(rows_to_strings(&rows), vec!["你a "]);
+    }
+
+    #[test]
+    fn blank_is_a_space_not_a_continuation() {
+        assert_eq!(EmuCell::blank().ch, " ");
+        assert_ne!(EmuCell::blank().ch, CONTINUATION);
+    }
 }

--- a/src/terminal/cell.rs
+++ b/src/terminal/cell.rs
@@ -11,9 +11,18 @@ use compact_str::CompactString;
 /// The 16 themeable palette slots (ANSI 0-15).
 ///
 /// Split out from [`Color::Idx`] by *numeric range*, not by how the escape
-/// sequence spelled it: backends disagree on spelling (alacritty has a `Named`
-/// variant, libghostty and xterm.js only carry palette indices) but all agree
-/// that 0-15 are the slots a theme may override.
+/// sequence spelled it, so `SGR 31` and `SGR 38;5;1` both land here.
+///
+/// The backends do not agree on whether that spelling survives parsing:
+/// alacritty keeps it (`Named` vs `Indexed`) and so does xterm.js (`CM_P16`
+/// vs `CM_P256`), but ghostty flattens both into one `.palette` value. A model
+/// that preserved the distinction would therefore be unimplementable on
+/// ghostty. The usual reason to want it, painting bold text bright, does not
+/// need it either: ghostty keys that off the index (`bold && idx < 8 =>
+/// palette[idx + 8]`), which applies to `38;5;1` just as much as to `31`.
+///
+/// What all three do agree on is that 0-15 are the slots a theme may override,
+/// which is the only distinction any consumer here acts on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum NamedColor {

--- a/src/terminal/cell.rs
+++ b/src/terminal/cell.rs
@@ -113,6 +113,19 @@ pub enum UnderlineStyle {
     Dashed,
 }
 
+impl UnderlineStyle {
+    /// The name this style goes by on the wire.
+    pub const fn name(self) -> &'static str {
+        match self {
+            UnderlineStyle::Single => "single",
+            UnderlineStyle::Double => "double",
+            UnderlineStyle::Curly => "curly",
+            UnderlineStyle::Dotted => "dotted",
+            UnderlineStyle::Dashed => "dashed",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Underline {
     pub style: UnderlineStyle,

--- a/src/terminal/cell.rs
+++ b/src/terminal/cell.rs
@@ -1,0 +1,56 @@
+//! Backend-neutral grid vocabulary.
+//!
+//! Every consumer of the terminal grid (render, assert, monitor, locator)
+//! speaks these types and nothing else, so swapping the emulator backend
+//! behind [`crate::terminal::emu::Emulator`] is invisible to them. Nothing in
+//! this module may depend on a specific emulator crate.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Color {
+    Default,
+    Idx(u8),
+    Rgb(u8, u8, u8),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmuCell {
+    /// Empty string means a blank cell (rendered as a space).
+    pub ch: String,
+    pub fg: Color,
+    pub bg: Color,
+    pub bold: bool,
+    pub dim: bool,
+    pub italic: bool,
+    pub underline: bool,
+    pub inverse: bool,
+    pub invisible: bool,
+    pub strike: bool,
+}
+
+impl Default for EmuCell {
+    fn default() -> Self {
+        EmuCell {
+            ch: String::new(),
+            fg: Color::Default,
+            bg: Color::Default,
+            bold: false,
+            dim: false,
+            italic: false,
+            underline: false,
+            inverse: false,
+            invisible: false,
+            strike: false,
+        }
+    }
+}
+
+/// Join a grid of cells into one string per row (blank cells → spaces).
+pub fn rows_to_strings(rows: &[Vec<EmuCell>]) -> Vec<String> {
+    rows.iter()
+        .map(|row| {
+            row.iter()
+                .map(|c| if c.ch.is_empty() { " " } else { c.ch.as_str() })
+                .collect::<String>()
+        })
+        .collect()
+}

--- a/src/terminal/conformance.rs
+++ b/src/terminal/conformance.rs
@@ -272,6 +272,49 @@ macro_rules! emulator_conformance_tests {
             );
         }
 
+        /// A wide char that does not fit in the last column wraps whole to the
+        /// next row, and the column it left behind is a blank it still owns.
+        /// Backends mark that filler with a distinct flag from a real
+        /// continuation; conflating the two loses a column and every row after
+        /// the wrap renders shifted.
+        #[test]
+        fn conformance_wide_char_wraps_at_the_line_edge() {
+            let mut e = conformance_emu(5, 3, 100);
+            e.process("abcd你".as_bytes());
+            let rows = e.viewable_rows();
+            assert_eq!(
+                rows[0][4].ch, " ",
+                "the column the wide char vacated is a blank"
+            );
+            assert_eq!(
+                rows[1][0].ch, "你",
+                "the wide char moved to the next row whole"
+            );
+            assert_eq!(
+                rows[1][1].ch,
+                $crate::terminal::cell::CONTINUATION,
+                "and takes its continuation with it"
+            );
+            let text = $crate::terminal::cell::rows_to_strings(&rows);
+            assert_eq!(text[0], "abcd ", "the padded row is still 5 columns wide");
+            assert_eq!(text[1], "你   ", "the wrapped row is 5 columns wide too");
+        }
+
+        /// A snapshot of text wrapping over several rows, wide char included.
+        /// Pinning the whole grid catches the off-by-one column errors that a
+        /// per-cell assertion reads past: here the wide char fits mid-row, so
+        /// no padding is involved and every row is exactly 5 columns.
+        #[test]
+        fn conformance_wrap_snapshot() {
+            let mut e = conformance_emu(5, 3, 100);
+            e.process("abcdefg你ij".as_bytes());
+            assert_eq!(
+                $crate::terminal::cell::rows_to_strings(&e.viewable_rows()),
+                // "fg你i" is 4 chars but 5 columns: 你 spans two.
+                ["abcde", "fg你i", "j    "]
+            );
+        }
+
         /// A multi-byte character split across reads must still decode. The
         /// reader fills a fixed 8 KiB buffer, so this happens on real output;
         /// a backend that decoded each chunk independently would corrupt the

--- a/src/terminal/conformance.rs
+++ b/src/terminal/conformance.rs
@@ -1,0 +1,290 @@
+//! Backend-agnostic conformance suite for [`crate::terminal::emu::Emulator`].
+//!
+//! Every backend must produce the same grid for the same bytes, otherwise
+//! swapping emulators silently changes what `expect`, `snapshot`, and the SVG
+//! renderer see. Backends opt in with one line:
+//!
+//! ```ignore
+//! crate::emulator_conformance_tests!(|c, r, s| Box::new(AlacrittyEmu::new(c, r, s)));
+//! ```
+//!
+//! Each case becomes a separate `#[test]` in the calling module, so a failure
+//! names the exact part of the contract that broke.
+
+/// Generates the conformance tests for one backend. `$make` builds a boxed
+/// emulator from `(cols, rows, scrollback)`.
+#[macro_export]
+macro_rules! emulator_conformance_tests {
+    ($make:expr) => {
+        #[allow(unused_imports)]
+        use $crate::terminal::cell::{rows_to_strings, Color};
+        #[allow(unused_imports)]
+        use $crate::terminal::emu::Emulator;
+
+        fn conformance_emu(cols: u16, rows: u16, scrollback: usize) -> Box<dyn Emulator> {
+            let make: fn(u16, u16, usize) -> Box<dyn Emulator> = $make;
+            make(cols, rows, scrollback)
+        }
+
+        /// The grid is always exactly `rows` x `cols`, regardless of content.
+        #[test]
+        fn conformance_grid_shape_is_exact() {
+            let mut e = conformance_emu(10, 4, 100);
+            e.process(b"hi");
+            let rows = e.viewable_rows();
+            assert_eq!(rows.len(), 4, "row count must equal terminal rows");
+            for row in &rows {
+                assert_eq!(row.len(), 10, "every row must be full width");
+            }
+            assert_eq!(e.size(), (10, 4));
+        }
+
+        /// Printable text lands on the grid, and untouched cells are blank.
+        #[test]
+        fn conformance_text_and_blank_cells() {
+            let mut e = conformance_emu(10, 2, 100);
+            e.process(b"abc");
+            let rows = e.viewable_rows();
+            assert_eq!(rows[0][0].ch, "a");
+            assert_eq!(rows[0][1].ch, "b");
+            assert_eq!(rows[0][2].ch, "c");
+            assert_eq!(
+                rows[0][3].ch, "",
+                "blank cells must be the empty string, not a space"
+            );
+            assert_eq!(rows_to_strings(&rows)[0], "abc       ");
+        }
+
+        /// CR/LF moves to the next row rather than wrapping text together.
+        #[test]
+        fn conformance_newline_moves_row() {
+            let mut e = conformance_emu(10, 3, 100);
+            e.process(b"one\r\ntwo");
+            let text = rows_to_strings(&e.viewable_rows());
+            assert_eq!(text[0].trim_end(), "one");
+            assert_eq!(text[1].trim_end(), "two");
+        }
+
+        /// Every SGR attribute the cell vocabulary exposes round-trips.
+        #[test]
+        fn conformance_sgr_attributes() {
+            let mut e = conformance_emu(20, 2, 100);
+            // bold, dim, italic, underline, inverse, hidden, strikethrough
+            e.process(b"\x1b[1;2;3;4;7;8;9mX\x1b[0mY");
+            let rows = e.viewable_rows();
+            let x = &rows[0][0];
+            assert!(x.bold, "bold");
+            assert!(x.dim, "dim");
+            assert!(x.italic, "italic");
+            assert!(x.underline, "underline");
+            assert!(x.inverse, "inverse");
+            assert!(x.invisible, "invisible");
+            assert!(x.strike, "strike");
+
+            let y = &rows[0][1];
+            assert!(!y.bold && !y.dim && !y.italic, "SGR 0 must reset");
+            assert!(!y.underline && !y.inverse && !y.invisible && !y.strike);
+        }
+
+        /// Extended underline styles still report as `underline`.
+        #[test]
+        fn conformance_extended_underline_is_underline() {
+            let mut e = conformance_emu(10, 2, 100);
+            e.process(b"\x1b[4:3mU");
+            assert!(
+                e.viewable_rows()[0][0].underline,
+                "curly underline must map to underline"
+            );
+        }
+
+        /// Named, 256-palette, and 24-bit colors map onto the color vocabulary.
+        #[test]
+        fn conformance_colors() {
+            let mut e = conformance_emu(20, 2, 100);
+            e.process(b"\x1b[31mR");
+            e.process(b"\x1b[38;5;196mP");
+            e.process(b"\x1b[38;2;10;20;30mT");
+            e.process(b"\x1b[0mD");
+            let rows = e.viewable_rows();
+            assert_eq!(rows[0][0].fg, Color::Idx(1), "named red is palette index 1");
+            assert_eq!(rows[0][1].fg, Color::Idx(196), "256-color palette index");
+            assert_eq!(rows[0][2].fg, Color::Rgb(10, 20, 30), "24-bit truecolor");
+            assert_eq!(
+                rows[0][3].fg,
+                Color::Default,
+                "reset returns to default, not an index"
+            );
+        }
+
+        /// Background colors are tracked independently of foreground.
+        #[test]
+        fn conformance_background_color() {
+            let mut e = conformance_emu(10, 2, 100);
+            e.process(b"\x1b[44mB");
+            let cell = e.viewable_rows()[0][0].clone();
+            assert_eq!(cell.bg, Color::Idx(4), "named blue background");
+            assert_eq!(cell.fg, Color::Default);
+        }
+
+        /// A double-width char occupies its cell; its spacer reads as blank so
+        /// text extraction keeps column alignment.
+        #[test]
+        fn conformance_wide_char_spacer_is_blank() {
+            let mut e = conformance_emu(10, 2, 100);
+            e.process("你a".as_bytes());
+            let rows = e.viewable_rows();
+            assert_eq!(rows[0][0].ch, "你");
+            assert_eq!(rows[0][1].ch, "", "wide-char spacer must be blank");
+            assert_eq!(rows[0][2].ch, "a", "next char sits after the spacer");
+        }
+
+        /// Cursor tracks writes and absolute positioning, 0-based as (x, y).
+        #[test]
+        fn conformance_cursor_position() {
+            let mut e = conformance_emu(10, 4, 100);
+            e.process(b"abc");
+            assert_eq!(e.cursor(), (3, 0), "cursor follows printed text");
+
+            e.process(b"\x1b[3;5H");
+            assert_eq!(e.cursor(), (4, 2), "CUP is 1-based, cursor() is 0-based");
+        }
+
+        /// The cursor never escapes the grid, even when driven past the edge.
+        #[test]
+        fn conformance_cursor_clamped_to_grid() {
+            let mut e = conformance_emu(10, 4, 100);
+            e.process(b"\x1b[999;999H");
+            let (x, y) = e.cursor();
+            assert!(x < 10, "cursor x {x} must stay inside 10 cols");
+            assert!(y < 4, "cursor y {y} must stay inside 4 rows");
+        }
+
+        /// Resizing updates the reported size and the grid shape.
+        #[test]
+        fn conformance_resize() {
+            let mut e = conformance_emu(10, 4, 100);
+            e.process(b"hello");
+            e.resize(20, 6);
+            assert_eq!(e.size(), (20, 6));
+            let rows = e.viewable_rows();
+            assert_eq!(rows.len(), 6);
+            assert_eq!(rows[0].len(), 20);
+        }
+
+        /// Scrolled-off lines leave the viewport but stay in `full_rows`.
+        #[test]
+        fn conformance_scrollback_retained() {
+            let mut e = conformance_emu(10, 3, 100);
+            e.process(b"L1\r\nL2\r\nL3\r\nL4\r\nL5\r\nL6");
+
+            let view = rows_to_strings(&e.viewable_rows());
+            assert_eq!(view.len(), 3);
+            assert_eq!(view[2].trim_end(), "L6", "viewport shows the newest line");
+            assert!(
+                !view.iter().any(|r| r.trim_end() == "L1"),
+                "L1 must have scrolled out of the viewport"
+            );
+
+            let full = rows_to_strings(&e.full_rows());
+            assert!(
+                full.len() > view.len(),
+                "full_rows must include scrollback: {} vs {}",
+                full.len(),
+                view.len()
+            );
+            assert!(
+                full.iter().any(|r| r.trim_end() == "L1"),
+                "scrolled-off L1 must survive in full_rows"
+            );
+            assert_eq!(
+                full.last().map(|r| r.trim_end().to_string()),
+                Some("L6".to_string()),
+                "full_rows ends with the newest line (history first, screen last)"
+            );
+        }
+
+        /// With no scrolling, history is empty and both views agree.
+        #[test]
+        fn conformance_full_rows_without_history() {
+            let mut e = conformance_emu(10, 4, 100);
+            e.process(b"only");
+            assert_eq!(
+                e.full_rows().len(),
+                e.viewable_rows().len(),
+                "no scroll means no extra history rows"
+            );
+        }
+
+        /// Queries that require an answer are queued for the PTY, and draining
+        /// is destructive so replies are not sent twice.
+        #[test]
+        fn conformance_pty_write_back() {
+            let mut e = conformance_emu(10, 4, 100);
+            assert!(
+                e.take_pending_writes().is_empty(),
+                "nothing pending before any query"
+            );
+
+            // Device Status Report: the terminal must answer with a position.
+            e.process(b"\x1b[6n");
+            let reply = e.take_pending_writes();
+            assert!(
+                !reply.is_empty(),
+                "DSR must produce a reply, or programs will hang waiting"
+            );
+            assert!(
+                reply.starts_with(b"\x1b["),
+                "reply should be a CSI sequence, got {:?}",
+                String::from_utf8_lossy(&reply)
+            );
+            assert!(
+                e.take_pending_writes().is_empty(),
+                "draining must consume the queue"
+            );
+        }
+
+        /// The alternate screen hides primary content and restores it on exit.
+        #[test]
+        fn conformance_alt_screen_round_trip() {
+            let mut e = conformance_emu(10, 3, 100);
+            e.process(b"primary");
+            e.process(b"\x1b[?1049h");
+            let alt = rows_to_strings(&e.viewable_rows());
+            assert!(
+                !alt.iter().any(|r| r.contains("primary")),
+                "alt screen must start clear"
+            );
+
+            e.process(b"\x1b[?1049l");
+            let back = rows_to_strings(&e.viewable_rows());
+            assert!(
+                back.iter().any(|r| r.contains("primary")),
+                "leaving alt screen restores primary content"
+            );
+        }
+
+        /// Erase sequences clear cells back to blank.
+        #[test]
+        fn conformance_erase_clears_cells() {
+            let mut e = conformance_emu(10, 2, 100);
+            e.process(b"abcdef");
+            e.process(b"\x1b[H\x1b[2J");
+            let text = rows_to_strings(&e.viewable_rows());
+            assert_eq!(text[0], "          ", "ED 2 clears the screen");
+        }
+
+        /// Byte-split escape sequences still parse; PTY reads chunk arbitrarily.
+        #[test]
+        fn conformance_split_escape_sequence() {
+            let mut e = conformance_emu(10, 2, 100);
+            e.process(b"\x1b[");
+            e.process(b"31m");
+            e.process(b"R");
+            assert_eq!(
+                e.viewable_rows()[0][0].fg,
+                Color::Idx(1),
+                "a sequence split across process() calls must still apply"
+            );
+        }
+    };
+}

--- a/src/terminal/conformance.rs
+++ b/src/terminal/conformance.rs
@@ -150,29 +150,57 @@ macro_rules! emulator_conformance_tests {
             // bold, dim, italic, underline, inverse, hidden, strikethrough
             e.process(b"\x1b[1;2;3;4;7;8;9mX\x1b[0mY");
             let rows = e.viewable_rows();
+            use $crate::terminal::cell::Attrs;
+            let set = Attrs::BOLD
+                | Attrs::DIM
+                | Attrs::ITALIC
+                | Attrs::INVERSE
+                | Attrs::INVISIBLE
+                | Attrs::STRIKE;
+
             let x = &rows[0][0];
-            assert!(x.bold, "bold");
-            assert!(x.dim, "dim");
-            assert!(x.italic, "italic");
-            assert!(x.underline, "underline");
-            assert!(x.inverse, "inverse");
-            assert!(x.invisible, "invisible");
-            assert!(x.strike, "strike");
+            assert_eq!(x.attrs, set, "every attribute in the SGR must be set");
+            assert!(x.underline.is_some(), "underline");
 
             let y = &rows[0][1];
             assert_eq!(y.ch, "Y");
-            assert!(!y.bold && !y.dim && !y.italic, "SGR 0 must reset");
-            assert!(!y.underline && !y.inverse && !y.invisible && !y.strike);
+            assert_eq!(y.attrs, Attrs::empty(), "SGR 0 must reset");
+            assert!(y.underline.is_none(), "SGR 0 must clear underline");
         }
 
-        /// Extended underline styles still report as `underline`.
+        /// Each extended underline reports its own style, not a flat boolean.
         #[test]
-        fn conformance_extended_underline_is_underline() {
+        fn conformance_underline_styles() {
+            use $crate::terminal::cell::UnderlineStyle::*;
+            for (seq, want) in [
+                (&b"\x1b[4m"[..], Single),
+                (&b"\x1b[4:2m"[..], Double),
+                (&b"\x1b[4:3m"[..], Curly),
+                (&b"\x1b[4:4m"[..], Dotted),
+                (&b"\x1b[4:5m"[..], Dashed),
+            ] {
+                let mut e = conformance_emu(10, 2, 100);
+                e.process(seq);
+                e.process(b"U");
+                let u = e.viewable_rows()[0][0]
+                    .underline
+                    .unwrap_or_else(|| panic!("{seq:?} must underline"));
+                assert_eq!(u.style, want, "{seq:?}");
+                assert_eq!(u.color, None, "no SGR 58 means it follows the fg");
+            }
+        }
+
+        /// SGR 58 colors the underline independently of the text.
+        #[test]
+        fn conformance_underline_color() {
             let mut e = conformance_emu(10, 2, 100);
-            e.process(b"\x1b[4:3mU");
-            assert!(
-                e.viewable_rows()[0][0].underline,
-                "curly underline must map to underline"
+            e.process(b"\x1b[31;4;58;5;33mU");
+            let cell = e.viewable_rows()[0][0].clone();
+            assert_eq!(cell.fg, Some($crate::terminal::cell::Color::from_index(1)));
+            assert_eq!(
+                cell.underline.and_then(|u| u.color),
+                Some($crate::terminal::cell::Color::from_index(33)),
+                "underline keeps its own color"
             );
         }
 
@@ -187,24 +215,22 @@ macro_rules! emulator_conformance_tests {
             let rows = e.viewable_rows();
             assert_eq!(
                 rows[0][0].fg,
-                $crate::terminal::cell::Color::Idx(1),
-                "named red is palette index 1"
+                Some($crate::terminal::cell::Color::Named(
+                    $crate::terminal::cell::NamedColor::Red
+                )),
+                "SGR 31 is the themeable red slot, not a fixed index"
             );
             assert_eq!(
                 rows[0][1].fg,
-                $crate::terminal::cell::Color::Idx(196),
-                "256-color palette index"
+                Some($crate::terminal::cell::Color::Idx(196)),
+                "256-color palette index stays an index"
             );
             assert_eq!(
                 rows[0][2].fg,
-                $crate::terminal::cell::Color::Rgb(10, 20, 30),
+                Some($crate::terminal::cell::Color::Rgb(10, 20, 30)),
                 "24-bit truecolor"
             );
-            assert_eq!(
-                rows[0][3].fg,
-                $crate::terminal::cell::Color::Default,
-                "reset returns to default, not an index"
-            );
+            assert_eq!(rows[0][3].fg, None, "reset returns to the terminal default");
         }
 
         /// Background colors are tracked independently of foreground.
@@ -215,22 +241,35 @@ macro_rules! emulator_conformance_tests {
             let cell = e.viewable_rows()[0][0].clone();
             assert_eq!(
                 cell.bg,
-                $crate::terminal::cell::Color::Idx(4),
+                Some($crate::terminal::cell::Color::Named(
+                    $crate::terminal::cell::NamedColor::Blue
+                )),
                 "named blue background"
             );
-            assert_eq!(cell.fg, $crate::terminal::cell::Color::Default);
+            assert_eq!(cell.fg, None);
         }
 
-        /// A double-width char occupies its cell; its spacer reads as blank so
-        /// text extraction keeps column alignment.
+        /// A double-width char owns both its columns: the second holds the
+        /// continuation marker, distinct from a blank cell's space, so text
+        /// extraction does not invent a column that the terminal never drew.
         #[test]
-        fn conformance_wide_char_spacer_is_blank() {
+        fn conformance_wide_char_continuation() {
             let mut e = conformance_emu(10, 2, 100);
             e.process("你a".as_bytes());
             let rows = e.viewable_rows();
             assert_eq!(rows[0][0].ch, "你");
-            assert_eq!(rows[0][1].ch, "", "wide-char spacer must be blank");
-            assert_eq!(rows[0][2].ch, "a", "next char sits after the spacer");
+            assert_eq!(
+                rows[0][1].ch,
+                $crate::terminal::cell::CONTINUATION,
+                "the second column of a wide char is a continuation, not a blank"
+            );
+            assert_eq!(rows[0][2].ch, "a", "next char sits after the continuation");
+            assert_eq!(rows[0][3].ch, " ", "an untouched cell is a blank space");
+            assert_eq!(
+                $crate::terminal::cell::rows_to_strings(&rows)[0],
+                "你a       ",
+                "the row is 10 columns wide, not 11"
+            );
         }
 
         /// A multi-byte character split across reads must still decode. The
@@ -460,7 +499,7 @@ macro_rules! emulator_conformance_tests {
             e.process(b"R");
             assert_eq!(
                 e.viewable_rows()[0][0].fg,
-                $crate::terminal::cell::Color::Idx(1),
+                Some($crate::terminal::cell::Color::from_index(1)),
                 "a sequence split across process() calls must still apply"
             );
         }

--- a/src/terminal/conformance.rs
+++ b/src/terminal/conformance.rs
@@ -335,12 +335,34 @@ macro_rules! emulator_conformance_tests {
             assert_eq!(text[1], "你   ", "the wrapped row is 5 columns wide too");
         }
 
-        /// A snapshot of text wrapping over several rows, wide char included.
-        /// Pinning the whole grid catches the off-by-one column errors that a
-        /// per-cell assertion reads past: here the wide char fits mid-row, so
-        /// no padding is involved and every row is exactly 5 columns.
+        /// The snapshot serializer, run against a real backend grid rather
+        /// than hand-built rows. This is the pairing that broke in practice:
+        /// the grid was right and `serialize` was right on its own inputs, but
+        /// the frame still came out misaligned because they disagreed on what
+        /// a continuation renders as. Any backend whose wrapping is off by a
+        /// column shows up here as a row that overruns the box.
         #[test]
-        fn conformance_wrap_snapshot() {
+        fn conformance_snapshot_frames_a_wrapped_wide_char() {
+            let mut e = conformance_emu(5, 3, 100);
+            e.process("abcd你".as_bytes());
+            assert_eq!(
+                $crate::assert::snapshot::serialize(&e.viewable_rows(), 5, false),
+                concat!(
+                    "\u{256d}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{256e}\n",
+                    "\u{2502}abcd \u{2502}\n",
+                    "\u{2502}\u{4f60}   \u{2502}\n",
+                    "\u{2502}     \u{2502}\n",
+                    "\u{2570}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{256f}",
+                )
+            );
+        }
+
+        /// The whole grid after text wraps over several rows, wide char
+        /// included. Pinning every row at once catches the off-by-one column
+        /// errors a per-cell assertion reads past: here the wide char fits
+        /// mid-row, so no padding is involved and every row is 5 columns.
+        #[test]
+        fn conformance_wrap_grid_over_several_rows() {
             let mut e = conformance_emu(5, 3, 100);
             e.process("abcdefg你ij".as_bytes());
             assert_eq!(

--- a/src/terminal/conformance.rs
+++ b/src/terminal/conformance.rs
@@ -10,20 +10,34 @@
 //!
 //! Each case becomes a separate `#[test]` in the calling module, so a failure
 //! names the exact part of the contract that broke.
+//!
+//! Assertions here encode the *contract*, not one implementation. Where real
+//! emulators legitimately diverge (reflow when shrinking below content width)
+//! the test pins only the part that is universal and says why it stops short.
 
 /// Generates the conformance tests for one backend. `$make` builds a boxed
 /// emulator from `(cols, rows, scrollback)`.
+///
+/// The body is fully path-qualified because it expands into the caller's
+/// module; it must not collide with whatever that module already imports.
 #[macro_export]
 macro_rules! emulator_conformance_tests {
     ($make:expr) => {
-        #[allow(unused_imports)]
-        use $crate::terminal::cell::{rows_to_strings, Color};
-        #[allow(unused_imports)]
-        use $crate::terminal::emu::Emulator;
-
-        fn conformance_emu(cols: u16, rows: u16, scrollback: usize) -> Box<dyn Emulator> {
-            let make: fn(u16, u16, usize) -> Box<dyn Emulator> = $make;
+        fn conformance_emu(
+            cols: u16,
+            rows: u16,
+            scrollback: usize,
+        ) -> Box<dyn $crate::terminal::emu::Emulator> {
+            let make: fn(u16, u16, usize) -> Box<dyn $crate::terminal::emu::Emulator> = $make;
             make(cols, rows, scrollback)
+        }
+
+        /// Row text with trailing blanks removed, for readable assertions.
+        fn conformance_text(rows: &[Vec<$crate::terminal::cell::EmuCell>]) -> Vec<String> {
+            $crate::terminal::cell::rows_to_strings(rows)
+                .into_iter()
+                .map(|r| r.trim_end().to_string())
+                .collect()
         }
 
         /// The grid is always exactly `rows` x `cols`, regardless of content.
@@ -39,7 +53,21 @@ macro_rules! emulator_conformance_tests {
             assert_eq!(e.size(), (10, 4));
         }
 
+        /// `full_rows` is as rectangular as `viewable_rows`; ragged history
+        /// rows would misalign the boxed snapshot output.
+        #[test]
+        fn conformance_full_rows_are_rectangular() {
+            let mut e = conformance_emu(10, 3, 100);
+            e.process(b"a\r\nbb\r\nccc\r\ndddd\r\neeeee");
+            for row in e.full_rows() {
+                assert_eq!(row.len(), 10, "history rows must be full width too");
+            }
+        }
+
         /// Printable text lands on the grid, and untouched cells are blank.
+        ///
+        /// A blank cell must be *fully* default: `expect --bg` and the SVG
+        /// renderer read color off cells the shell never painted.
         #[test]
         fn conformance_text_and_blank_cells() {
             let mut e = conformance_emu(10, 2, 100);
@@ -49,10 +77,14 @@ macro_rules! emulator_conformance_tests {
             assert_eq!(rows[0][1].ch, "b");
             assert_eq!(rows[0][2].ch, "c");
             assert_eq!(
-                rows[0][3].ch, "",
-                "blank cells must be the empty string, not a space"
+                rows[0][3],
+                $crate::terminal::cell::EmuCell::default(),
+                "an untouched cell must be blank with default colors and no attributes"
             );
-            assert_eq!(rows_to_strings(&rows)[0], "abc       ");
+            assert_eq!(
+                $crate::terminal::cell::rows_to_strings(&rows)[0],
+                "abc       "
+            );
         }
 
         /// CR/LF moves to the next row rather than wrapping text together.
@@ -60,9 +92,55 @@ macro_rules! emulator_conformance_tests {
         fn conformance_newline_moves_row() {
             let mut e = conformance_emu(10, 3, 100);
             e.process(b"one\r\ntwo");
-            let text = rows_to_strings(&e.viewable_rows());
-            assert_eq!(text[0].trim_end(), "one");
-            assert_eq!(text[1].trim_end(), "two");
+            let text = conformance_text(&e.viewable_rows());
+            assert_eq!(text[0], "one");
+            assert_eq!(text[1], "two");
+        }
+
+        /// A bare CR returns to column 0 so later bytes overwrite in place.
+        /// Progress bars and readline redraws depend on this.
+        #[test]
+        fn conformance_carriage_return_overwrites() {
+            let mut e = conformance_emu(10, 2, 100);
+            e.process(b"12345\rab");
+            assert_eq!(conformance_text(&e.viewable_rows())[0], "ab345");
+        }
+
+        /// Backspace moves the cursor back without erasing; the next byte
+        /// overwrites in place.
+        #[test]
+        fn conformance_backspace_moves_cursor() {
+            let mut e = conformance_emu(10, 2, 100);
+            e.process(b"abc\x08X");
+            assert_eq!(conformance_text(&e.viewable_rows())[0], "abX");
+            assert_eq!(e.cursor(), (3, 0));
+        }
+
+        /// Text longer than the row wraps onto the next row. `expect text` and
+        /// `locator::find` flatten the grid, so wrap placement is observable.
+        #[test]
+        fn conformance_autowrap_at_right_margin() {
+            let mut e = conformance_emu(5, 3, 100);
+            e.process(b"abcdefgh");
+            let text = conformance_text(&e.viewable_rows());
+            assert_eq!(text[0], "abcde", "first row fills to the margin");
+            assert_eq!(text[1], "fgh", "the remainder continues on the next row");
+        }
+
+        /// A tab advances the cursor to the next 8-column tab stop.
+        ///
+        /// What a backend leaves *in* the skipped cells is genuinely
+        /// divergent — alacritty stores a literal `\t` there, others store
+        /// blanks — so this pins only cursor advance and landing column,
+        /// which every emulator agrees on.
+        #[test]
+        fn conformance_tab_advances_to_stop() {
+            let mut e = conformance_emu(20, 2, 100);
+            e.process(b"a\tb");
+            let rows = e.viewable_rows();
+            assert_eq!(rows[0][0].ch, "a");
+            assert_eq!(rows[0][8].ch, "b", "next glyph lands on the 8-column stop");
+            assert_eq!(e.cursor(), (9, 0), "cursor sits just past the tab stop");
         }
 
         /// Every SGR attribute the cell vocabulary exposes round-trips.
@@ -82,6 +160,7 @@ macro_rules! emulator_conformance_tests {
             assert!(x.strike, "strike");
 
             let y = &rows[0][1];
+            assert_eq!(y.ch, "Y");
             assert!(!y.bold && !y.dim && !y.italic, "SGR 0 must reset");
             assert!(!y.underline && !y.inverse && !y.invisible && !y.strike);
         }
@@ -106,12 +185,24 @@ macro_rules! emulator_conformance_tests {
             e.process(b"\x1b[38;2;10;20;30mT");
             e.process(b"\x1b[0mD");
             let rows = e.viewable_rows();
-            assert_eq!(rows[0][0].fg, Color::Idx(1), "named red is palette index 1");
-            assert_eq!(rows[0][1].fg, Color::Idx(196), "256-color palette index");
-            assert_eq!(rows[0][2].fg, Color::Rgb(10, 20, 30), "24-bit truecolor");
+            assert_eq!(
+                rows[0][0].fg,
+                $crate::terminal::cell::Color::Idx(1),
+                "named red is palette index 1"
+            );
+            assert_eq!(
+                rows[0][1].fg,
+                $crate::terminal::cell::Color::Idx(196),
+                "256-color palette index"
+            );
+            assert_eq!(
+                rows[0][2].fg,
+                $crate::terminal::cell::Color::Rgb(10, 20, 30),
+                "24-bit truecolor"
+            );
             assert_eq!(
                 rows[0][3].fg,
-                Color::Default,
+                $crate::terminal::cell::Color::Default,
                 "reset returns to default, not an index"
             );
         }
@@ -122,8 +213,12 @@ macro_rules! emulator_conformance_tests {
             let mut e = conformance_emu(10, 2, 100);
             e.process(b"\x1b[44mB");
             let cell = e.viewable_rows()[0][0].clone();
-            assert_eq!(cell.bg, Color::Idx(4), "named blue background");
-            assert_eq!(cell.fg, Color::Default);
+            assert_eq!(
+                cell.bg,
+                $crate::terminal::cell::Color::Idx(4),
+                "named blue background"
+            );
+            assert_eq!(cell.fg, $crate::terminal::cell::Color::Default);
         }
 
         /// A double-width char occupies its cell; its spacer reads as blank so
@@ -138,6 +233,19 @@ macro_rules! emulator_conformance_tests {
             assert_eq!(rows[0][2].ch, "a", "next char sits after the spacer");
         }
 
+        /// A multi-byte character split across reads must still decode. The
+        /// reader fills a fixed 8 KiB buffer, so this happens on real output;
+        /// a backend that decoded each chunk independently would corrupt the
+        /// grid here while passing every other case.
+        #[test]
+        fn conformance_split_utf8_sequence() {
+            let mut e = conformance_emu(10, 2, 100);
+            let text = "héllo".as_bytes();
+            e.process(&text[..2]); // splits the two-byte 'é'
+            e.process(&text[2..]);
+            assert_eq!(conformance_text(&e.viewable_rows())[0], "héllo");
+        }
+
         /// Cursor tracks writes and absolute positioning, 0-based as (x, y).
         #[test]
         fn conformance_cursor_position() {
@@ -149,43 +257,75 @@ macro_rules! emulator_conformance_tests {
             assert_eq!(e.cursor(), (4, 2), "CUP is 1-based, cursor() is 0-based");
         }
 
-        /// The cursor never escapes the grid, even when driven past the edge.
+        /// Positioning past the edge clamps to the last cell, rather than
+        /// wrapping, saturating to zero, or escaping the grid.
         #[test]
         fn conformance_cursor_clamped_to_grid() {
             let mut e = conformance_emu(10, 4, 100);
             e.process(b"\x1b[999;999H");
-            let (x, y) = e.cursor();
-            assert!(x < 10, "cursor x {x} must stay inside 10 cols");
-            assert!(y < 4, "cursor y {y} must stay inside 4 rows");
+            assert_eq!(
+                e.cursor(),
+                (9, 3),
+                "out-of-range CUP clamps to the bottom-right cell"
+            );
         }
 
-        /// Resizing updates the reported size and the grid shape.
+        /// Growing the terminal updates the reported size and keeps content.
         #[test]
-        fn conformance_resize() {
+        fn conformance_resize_grow_preserves_content() {
             let mut e = conformance_emu(10, 4, 100);
             e.process(b"hello");
             e.resize(20, 6);
+
             assert_eq!(e.size(), (20, 6));
             let rows = e.viewable_rows();
             assert_eq!(rows.len(), 6);
             assert_eq!(rows[0].len(), 20);
+            assert_eq!(
+                conformance_text(&rows)[0],
+                "hello",
+                "growing must not discard existing content"
+            );
         }
 
-        /// Scrolled-off lines leave the viewport but stay in `full_rows`.
+        /// Shrinking reports the new size and keeps content that still fits.
+        ///
+        /// Reflow of content wider than the new width legitimately differs
+        /// between emulators, so this pins only the narrow, universal case.
         #[test]
-        fn conformance_scrollback_retained() {
+        fn conformance_resize_shrink_keeps_fitting_content() {
+            let mut e = conformance_emu(20, 6, 100);
+            e.process(b"hey");
+            e.resize(10, 4);
+
+            assert_eq!(e.size(), (10, 4));
+            let rows = e.viewable_rows();
+            assert_eq!(rows.len(), 4);
+            assert_eq!(rows[0].len(), 10);
+            assert!(
+                conformance_text(&rows).iter().any(|r| r == "hey"),
+                "content narrower than the new width must survive shrinking"
+            );
+        }
+
+        /// Scrolled-off lines leave the viewport but stay in `full_rows`, and
+        /// `full_rows` ends with exactly the viewport. `grid(full = true)` in
+        /// the daemon depends on that ordering.
+        #[test]
+        fn conformance_scrollback_retained_and_ordered() {
             let mut e = conformance_emu(10, 3, 100);
             e.process(b"L1\r\nL2\r\nL3\r\nL4\r\nL5\r\nL6");
 
-            let view = rows_to_strings(&e.viewable_rows());
-            assert_eq!(view.len(), 3);
-            assert_eq!(view[2].trim_end(), "L6", "viewport shows the newest line");
+            let view = e.viewable_rows();
+            let view_text = conformance_text(&view);
+            assert_eq!(view_text.len(), 3);
+            assert_eq!(view_text[2], "L6", "viewport shows the newest line");
             assert!(
-                !view.iter().any(|r| r.trim_end() == "L1"),
+                !view_text.iter().any(|r| r == "L1"),
                 "L1 must have scrolled out of the viewport"
             );
 
-            let full = rows_to_strings(&e.full_rows());
+            let full = e.full_rows();
             assert!(
                 full.len() > view.len(),
                 "full_rows must include scrollback: {} vs {}",
@@ -193,49 +333,69 @@ macro_rules! emulator_conformance_tests {
                 view.len()
             );
             assert!(
-                full.iter().any(|r| r.trim_end() == "L1"),
+                conformance_text(&full).iter().any(|r| r == "L1"),
                 "scrolled-off L1 must survive in full_rows"
             );
             assert_eq!(
-                full.last().map(|r| r.trim_end().to_string()),
-                Some("L6".to_string()),
-                "full_rows ends with the newest line (history first, screen last)"
+                &full[full.len() - view.len()..],
+                &view[..],
+                "full_rows must be history followed by exactly the viewport"
             );
         }
 
-        /// With no scrolling, history is empty and both views agree.
+        /// With no scrolling, history is empty and `full_rows` *is* the
+        /// viewport.
         #[test]
         fn conformance_full_rows_without_history() {
             let mut e = conformance_emu(10, 4, 100);
             e.process(b"only");
             assert_eq!(
-                e.full_rows().len(),
-                e.viewable_rows().len(),
-                "no scroll means no extra history rows"
+                e.full_rows(),
+                e.viewable_rows(),
+                "no scroll means full_rows matches the viewport exactly"
+            );
+        }
+
+        /// The scrollback limit is honored. A backend that ignores it grows
+        /// without bound in a long-lived daemon session.
+        #[test]
+        fn conformance_scrollback_is_bounded() {
+            let rows = 3u16;
+            let scrollback = 2usize;
+            let mut e = conformance_emu(10, rows, scrollback);
+            for i in 0..20 {
+                e.process(format!("line{i}\r\n").as_bytes());
+            }
+            let total = e.full_rows().len();
+            assert!(
+                total >= rows as usize,
+                "full_rows ({total}) must still contain the viewport"
+            );
+            assert!(
+                total <= rows as usize + scrollback + 1,
+                "full_rows ({total}) must respect the {scrollback}-row scrollback limit"
             );
         }
 
         /// Queries that require an answer are queued for the PTY, and draining
-        /// is destructive so replies are not sent twice.
+        /// is destructive so replies are not sent twice. The reply must be
+        /// available as soon as `process` returns: a backend that parsed
+        /// asynchronously would hang every program that probes the terminal.
         #[test]
         fn conformance_pty_write_back() {
             let mut e = conformance_emu(10, 4, 100);
-            assert!(
-                e.take_pending_writes().is_empty(),
-                "nothing pending before any query"
-            );
+            // A backend may queue its own startup handshake; only the reply to
+            // our query matters.
+            let _ = e.take_pending_writes();
 
-            // Device Status Report: the terminal must answer with a position.
-            e.process(b"\x1b[6n");
+            // Device Status Report: the terminal must answer with the cursor
+            // position, 1-based, as CSI <row> ; <col> R.
+            e.process(b"\x1b[3;5H\x1b[6n");
             let reply = e.take_pending_writes();
-            assert!(
-                !reply.is_empty(),
-                "DSR must produce a reply, or programs will hang waiting"
-            );
-            assert!(
-                reply.starts_with(b"\x1b["),
-                "reply should be a CSI sequence, got {:?}",
-                String::from_utf8_lossy(&reply)
+            assert_eq!(
+                String::from_utf8_lossy(&reply),
+                "\x1b[3;5R",
+                "DSR must report the cursor position, or programs hang waiting"
             );
             assert!(
                 e.take_pending_writes().is_empty(),
@@ -249,28 +409,46 @@ macro_rules! emulator_conformance_tests {
             let mut e = conformance_emu(10, 3, 100);
             e.process(b"primary");
             e.process(b"\x1b[?1049h");
-            let alt = rows_to_strings(&e.viewable_rows());
+            let alt = conformance_text(&e.viewable_rows());
             assert!(
                 !alt.iter().any(|r| r.contains("primary")),
                 "alt screen must start clear"
             );
 
             e.process(b"\x1b[?1049l");
-            let back = rows_to_strings(&e.viewable_rows());
+            let back = conformance_text(&e.viewable_rows());
             assert!(
                 back.iter().any(|r| r.contains("primary")),
                 "leaving alt screen restores primary content"
             );
         }
 
-        /// Erase sequences clear cells back to blank.
+        /// Erase resets cells to fully default, not merely to a space.
         #[test]
         fn conformance_erase_clears_cells() {
             let mut e = conformance_emu(10, 2, 100);
             e.process(b"abcdef");
             e.process(b"\x1b[H\x1b[2J");
-            let text = rows_to_strings(&e.viewable_rows());
-            assert_eq!(text[0], "          ", "ED 2 clears the screen");
+            for (x, cell) in e.viewable_rows()[0].iter().enumerate() {
+                assert_eq!(
+                    cell,
+                    &$crate::terminal::cell::EmuCell::default(),
+                    "ED 2 must reset cell {x} to a default cell"
+                );
+            }
+        }
+
+        /// Erase to end of line clears from the cursor rightward only.
+        #[test]
+        fn conformance_erase_line_from_cursor() {
+            let mut e = conformance_emu(10, 2, 100);
+            e.process(b"abcdef");
+            e.process(b"\x1b[1;4H\x1b[K");
+            assert_eq!(
+                conformance_text(&e.viewable_rows())[0],
+                "abc",
+                "EL clears from the cursor to end of line, keeping the prefix"
+            );
         }
 
         /// Byte-split escape sequences still parse; PTY reads chunk arbitrarily.
@@ -282,7 +460,7 @@ macro_rules! emulator_conformance_tests {
             e.process(b"R");
             assert_eq!(
                 e.viewable_rows()[0][0].fg,
-                Color::Idx(1),
+                $crate::terminal::cell::Color::Idx(1),
                 "a sequence split across process() calls must still apply"
             );
         }

--- a/src/terminal/conformance.rs
+++ b/src/terminal/conformance.rs
@@ -160,33 +160,40 @@ macro_rules! emulator_conformance_tests {
 
             let x = &rows[0][0];
             assert_eq!(x.attrs, set, "every attribute in the SGR must be set");
-            assert!(x.underline.is_some(), "underline");
+            assert!(x.underline.is_underlined(), "underline");
 
             let y = &rows[0][1];
             assert_eq!(y.ch, "Y");
             assert_eq!(y.attrs, Attrs::empty(), "SGR 0 must reset");
-            assert!(y.underline.is_none(), "SGR 0 must clear underline");
+            assert_eq!(
+                y.underline,
+                $crate::terminal::cell::UnderlineStyle::None,
+                "SGR 0 must clear underline"
+            );
         }
 
         /// Each extended underline reports its own style, not a flat boolean.
         #[test]
         fn conformance_underline_styles() {
-            use $crate::terminal::cell::UnderlineStyle::*;
+            // Aliased, not glob-imported: `UnderlineStyle::None` would shadow
+            // `Option::None` in this scope.
+            use $crate::terminal::cell::UnderlineStyle as U;
             for (seq, want) in [
-                (&b"\x1b[4m"[..], Single),
-                (&b"\x1b[4:2m"[..], Double),
-                (&b"\x1b[4:3m"[..], Curly),
-                (&b"\x1b[4:4m"[..], Dotted),
-                (&b"\x1b[4:5m"[..], Dashed),
+                (&b"\x1b[4m"[..], U::Single),
+                (&b"\x1b[4:2m"[..], U::Double),
+                (&b"\x1b[4:3m"[..], U::Curly),
+                (&b"\x1b[4:4m"[..], U::Dotted),
+                (&b"\x1b[4:5m"[..], U::Dashed),
             ] {
                 let mut e = conformance_emu(10, 2, 100);
                 e.process(seq);
                 e.process(b"U");
-                let u = e.viewable_rows()[0][0]
-                    .underline
-                    .unwrap_or_else(|| panic!("{seq:?} must underline"));
-                assert_eq!(u.style, want, "{seq:?}");
-                assert_eq!(u.color, None, "no SGR 58 means it follows the fg");
+                let cell = e.viewable_rows()[0][0].clone();
+                assert_eq!(cell.underline, want, "{seq:?}");
+                assert_eq!(
+                    cell.underline_color, None,
+                    "no SGR 58 means it follows the fg"
+                );
             }
         }
 
@@ -198,10 +205,38 @@ macro_rules! emulator_conformance_tests {
             let cell = e.viewable_rows()[0][0].clone();
             assert_eq!(cell.fg, Some($crate::terminal::cell::Color::from_index(1)));
             assert_eq!(
-                cell.underline.and_then(|u| u.color),
+                cell.underline_color,
                 Some($crate::terminal::cell::Color::from_index(33)),
                 "underline keeps its own color"
             );
+        }
+
+        /// The underline's color is tracked separately from its shape, so
+        /// SGR 58 survives a cell that is not underlined and SGR 24 leaves it
+        /// alone. Only a full reset clears both.
+        #[test]
+        fn conformance_underline_color_outlives_the_underline() {
+            use $crate::terminal::cell::{Color, UnderlineStyle as U};
+            let mut e = conformance_emu(10, 2, 100);
+            e.process(b"\x1b[58;5;33mA\x1b[4mB\x1b[24mC\x1b[0mD");
+            let rows = e.viewable_rows();
+
+            assert_eq!(rows[0][0].underline, U::None, "58 alone does not underline");
+            assert_eq!(
+                rows[0][0].underline_color,
+                Some(Color::from_index(33)),
+                "but its color is still tracked"
+            );
+            assert_eq!(rows[0][1].underline, U::Single, "4 turns it on");
+            assert_eq!(rows[0][1].underline_color, Some(Color::from_index(33)));
+            assert_eq!(rows[0][2].underline, U::None, "24 turns it off");
+            assert_eq!(
+                rows[0][2].underline_color,
+                Some(Color::from_index(33)),
+                "24 clears the shape, not the color"
+            );
+            assert_eq!(rows[0][3].underline, U::None, "0 resets everything");
+            assert_eq!(rows[0][3].underline_color, None);
         }
 
         /// Named, 256-palette, and 24-bit colors map onto the color vocabulary.

--- a/src/terminal/emu.rs
+++ b/src/terminal/emu.rs
@@ -1,202 +1,43 @@
-//! Terminal-emulator wrapper around `alacritty_terminal`. Exposes the small
-//! grid/cell/color surface the rest of shell-use consumes, plus a capture
-//! proxy that queues the terminal's replies so the reader can forward them
-//! back to the PTY.
+//! The terminal-emulator seam.
+//!
+//! shell-use drives a PTY and reads back a cell grid. [`Emulator`] is the
+//! entire contract between the two, so an emulator backend can be swapped
+//! without touching render, assert, monitor, or the daemon.
+//!
+//! Command/exit/cwd tracking is deliberately *not* part of this trait: it is
+//! derived from the raw PTY byte stream by [`crate::terminal::integration`],
+//! which is backend-independent. Keeping it out means every backend reports
+//! identical shell-integration behavior by construction rather than by
+//! reimplementation.
 
-use std::sync::{Arc, Mutex};
+use crate::terminal::cell::EmuCell;
 
-use alacritty_terminal::event::{Event, EventListener};
-use alacritty_terminal::grid::Dimensions;
-use alacritty_terminal::index::{Column, Line};
-use alacritty_terminal::term::cell::Flags as AlacFlags;
-use alacritty_terminal::term::test::TermSize;
-use alacritty_terminal::term::{Config as AlacConfig, Term};
-use alacritty_terminal::vte::ansi;
+/// A headless terminal emulator: bytes in, cell grid out.
+///
+/// Implementations must be `Send`; the daemon shares the emulator across its
+/// reader, request, and monitor threads behind a mutex. A backend whose native
+/// handle is `!Send` is expected to confine that handle to its own thread and
+/// implement this trait on a `Send` handle.
+pub trait Emulator: Send {
+    /// Feed PTY output bytes into the emulator.
+    fn process(&mut self, bytes: &[u8]);
 
-use crate::terminal::integration::CommandTracker;
+    /// Drain bytes the emulator wants written back to the PTY (device
+    /// attribute replies, cursor position reports, and similar). The caller
+    /// forwards these to the PTY.
+    fn take_pending_writes(&mut self) -> Vec<u8>;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Color {
-    Default,
-    Idx(u8),
-    Rgb(u8, u8, u8),
-}
+    fn resize(&mut self, cols: u16, rows: u16);
 
-impl Color {
-    fn from_alac(c: ansi::Color) -> Self {
-        match c {
-            ansi::Color::Named(named) => match named {
-                ansi::NamedColor::Foreground | ansi::NamedColor::Background => Color::Default,
-                other => Color::Idx(other as u8),
-            },
-            ansi::Color::Spec(rgb) => Color::Rgb(rgb.r, rgb.g, rgb.b),
-            ansi::Color::Indexed(i) => Color::Idx(i),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct EmuCell {
-    /// Empty string means a blank cell (rendered as a space).
-    pub ch: String,
-    pub fg: Color,
-    pub bg: Color,
-    pub bold: bool,
-    pub dim: bool,
-    pub italic: bool,
-    pub underline: bool,
-    pub inverse: bool,
-    pub invisible: bool,
-    pub strike: bool,
-}
-
-fn cell_from_alac(c: &alacritty_terminal::term::cell::Cell) -> EmuCell {
-    let flags = c.flags;
-    let spacer = flags.contains(AlacFlags::WIDE_CHAR_SPACER)
-        || flags.contains(AlacFlags::LEADING_WIDE_CHAR_SPACER);
-    let ch = if spacer || (c.c == ' ' && !flags.contains(AlacFlags::WIDE_CHAR)) {
-        String::new()
-    } else {
-        c.c.to_string()
-    };
-    EmuCell {
-        ch,
-        fg: Color::from_alac(c.fg),
-        bg: Color::from_alac(c.bg),
-        bold: flags.contains(AlacFlags::BOLD),
-        dim: flags.contains(AlacFlags::DIM),
-        italic: flags.contains(AlacFlags::ITALIC),
-        underline: flags.intersects(
-            AlacFlags::UNDERLINE
-                | AlacFlags::DOUBLE_UNDERLINE
-                | AlacFlags::DOTTED_UNDERLINE
-                | AlacFlags::DASHED_UNDERLINE
-                | AlacFlags::UNDERCURL,
-        ),
-        inverse: flags.contains(AlacFlags::INVERSE),
-        invisible: flags.contains(AlacFlags::HIDDEN),
-        strike: flags.contains(AlacFlags::STRIKEOUT),
-    }
-}
-
-#[derive(Default, Clone)]
-struct CaptureProxy {
-    pending: Arc<Mutex<Vec<u8>>>,
-}
-
-impl EventListener for CaptureProxy {
-    fn send_event(&self, ev: Event) {
-        if let Event::PtyWrite(bytes) = ev {
-            if let Ok(mut buf) = self.pending.lock() {
-                buf.extend_from_slice(bytes.as_bytes());
-            }
-        }
-    }
-}
-
-pub struct Emu {
-    term: Term<CaptureProxy>,
-    processor: ansi::Processor,
-    tracker: CommandTracker,
-    cols: u16,
-    rows: u16,
-    pending: Arc<Mutex<Vec<u8>>>,
-}
-
-impl Emu {
-    pub fn new(cols: u16, rows: u16, scrollback: usize) -> Self {
-        let size = TermSize::new(cols as usize, rows as usize);
-        let config = AlacConfig {
-            scrolling_history: scrollback,
-            ..Default::default()
-        };
-        let pending: Arc<Mutex<Vec<u8>>> = Arc::default();
-        let proxy = CaptureProxy {
-            pending: pending.clone(),
-        };
-        Emu {
-            term: Term::new(config, &size, proxy),
-            processor: ansi::Processor::new(),
-            tracker: CommandTracker::new(),
-            cols,
-            rows,
-            pending,
-        }
-    }
-
-    /// Feed PTY bytes through the terminal emulator and the command tracker.
-    pub fn process(&mut self, bytes: &[u8]) {
-        self.processor.advance(&mut self.term, bytes);
-        self.tracker.feed(bytes);
-    }
-
-    /// Access the command tracker.
-    pub fn tracker(&self) -> &CommandTracker {
-        &self.tracker
-    }
-
-    pub fn take_pending_writes(&mut self) -> Vec<u8> {
-        match self.pending.lock() {
-            Ok(mut buf) => std::mem::take(&mut *buf),
-            Err(_) => Vec::new(),
-        }
-    }
-
-    pub fn resize(&mut self, cols: u16, rows: u16) {
-        self.term
-            .resize(TermSize::new(cols as usize, rows as usize));
-        self.cols = cols;
-        self.rows = rows;
-    }
-
-    pub fn size(&self) -> (u16, u16) {
-        (self.cols, self.rows)
-    }
+    /// Current grid size as `(cols, rows)`.
+    fn size(&self) -> (u16, u16);
 
     /// Cursor position as `(x, y)` (column, row), 0-based, clamped to screen.
-    pub fn cursor(&self) -> (u16, u16) {
-        let p = self.term.grid().cursor.point;
-        let y = p.line.0.max(0).min(self.rows as i32 - 1) as u16;
-        let x = (p.column.0 as u16).min(self.cols.saturating_sub(1));
-        (x, y)
-    }
+    fn cursor(&self) -> (u16, u16);
 
-    /// Visible screen as rows of cells.
-    pub fn viewable_rows(&self) -> Vec<Vec<EmuCell>> {
-        self.rows_in_range(0, self.rows as i32)
-    }
+    /// Visible screen as rows of cells. Always `rows` entries of `cols` cells.
+    fn viewable_rows(&self) -> Vec<Vec<EmuCell>>;
 
-    /// History + visible screen as rows of cells.
-    pub fn full_rows(&self) -> Vec<Vec<EmuCell>> {
-        let grid = self.term.grid();
-        let total = grid.total_lines() as i32;
-        let screen = grid.screen_lines() as i32;
-        let history = (total - screen).max(0);
-        self.rows_in_range(-history, screen)
-    }
-
-    fn rows_in_range(&self, start: i32, end: i32) -> Vec<Vec<EmuCell>> {
-        let grid = self.term.grid();
-        let mut out = Vec::with_capacity((end - start).max(0) as usize);
-        for line in start..end {
-            let mut row = Vec::with_capacity(self.cols as usize);
-            for col in 0..self.cols as usize {
-                let cell = &grid[Line(line)][Column(col)];
-                row.push(cell_from_alac(cell));
-            }
-            out.push(row);
-        }
-        out
-    }
-}
-
-/// Join a grid of cells into one string per row (blank cells → spaces).
-pub fn rows_to_strings(rows: &[Vec<EmuCell>]) -> Vec<String> {
-    rows.iter()
-        .map(|row| {
-            row.iter()
-                .map(|c| if c.ch.is_empty() { " " } else { c.ch.as_str() })
-                .collect::<String>()
-        })
-        .collect()
+    /// Scrollback history followed by the visible screen.
+    fn full_rows(&self) -> Vec<Vec<EmuCell>>;
 }

--- a/src/terminal/locator.rs
+++ b/src/terminal/locator.rs
@@ -3,7 +3,7 @@
 
 use regex::Regex;
 
-use super::emu::EmuCell;
+use super::cell::EmuCell;
 
 pub enum Pattern {
     Text(String),

--- a/src/terminal/locator.rs
+++ b/src/terminal/locator.rs
@@ -45,20 +45,13 @@ pub fn find(
         return Ok(None);
     }
     let width = rows.iter().map(|r| r.len()).max().unwrap_or(0);
+    // One char per *column*, so match offsets map straight back to (x, y).
+    // A continuation cell holds no grapheme but still occupies its column, so
+    // it gets a filler here rather than being skipped as in `rows_to_strings`.
     let chars: Vec<char> = rows
         .iter()
         .flat_map(|row| {
-            (0..width).map(move |x| {
-                row.get(x)
-                    .map(|c| {
-                        if c.ch.is_empty() {
-                            ' '
-                        } else {
-                            c.ch.chars().next().unwrap_or(' ')
-                        }
-                    })
-                    .unwrap_or(' ')
-            })
+            (0..width).map(move |x| row.get(x).and_then(|c| c.ch.chars().next()).unwrap_or(' '))
         })
         .collect();
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1,3 +1,5 @@
+pub mod alacritty;
+pub mod cell;
 pub mod emu;
 pub mod integration;
 pub mod locator;

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1,5 +1,7 @@
 pub mod alacritty;
 pub mod cell;
+#[cfg(test)]
+pub mod conformance;
 pub mod emu;
 pub mod integration;
 pub mod locator;


### PR DESCRIPTION
Puts the terminal emulator behind an `Emulator` trait so additional backends (libghostty, xterm.js) can be added without touching the daemon, render, or assert layers, then makes the neutral grid vocabulary lossless enough for those backends to agree on.

**The seam**

- `Emu` → `AlacrittyEmu`, now the first `impl Emulator`; neutral grid types moved to `terminal::cell`
- `CommandTracker` lifted out of the emulator into `TermState` — OSC 133/633/7 parsing is backend-neutral, so every backend gets identical shell integration by construction rather than reimplementing it
- adds `emulator_conformance_tests!`, backend-agnostic tests any new backend has to pass

**The cell model**

The vocabulary flattened away detail the emulator had already parsed, and each loss surfaced downstream:

- `Color::Default` was indistinguishable from ANSI 0, so `expect --fg 0` matched a default-colored cell and reported it as black when the theme paints it light gray. Colors are `Option<Color>`; a default cell matches nothing.
- A blank cell and the second column of a double-width character were both `""`, and text extraction substituted a space for each — inventing a column, so `你a` extracted as `你 a` and shifted every column after it. Blanks hold a real space, `""` means continuation, extraction skips it.
- Five underline styles collapsed into one bool and the underline color was dropped. `Option<Underline>` keeps both.
- Palette slots 0-15 are themeable and 16-255 are fixed, but both landed in `Color::Idx`. Now `Color::Named` and `Color::Idx`, split by numeric range rather than by how the escape sequence spelled it, so a backend that only carries a palette index agrees with one that carries a name.

Attributes move into a `bitflags` set, which adds blink and reduces the per-cell style comparison in the render and monitor loops to one integer compare. `ch` becomes a `CompactString`, inline up to 24 bytes, so the grid stops heap-allocating per cell and can hold combining marks the backend was discarding.

**Wire format**

Colors are unchanged: named and indexed both serialize to their palette index. `cells` was reporting four of seven attributes, so `dim`, `invisible`, `strike` and `blink` are added along with `underline_style` and `underline_color`. `blink` is always false from alacritty, which parses SGR 5/6/25 and discards them, but ghostty and xterm.js both track it. A continuation cell now reports `""` rather than a space; the binding types document it.