### PR TITLE
test(js): read the cursor next to the state it is compared against

### DIFF
--- a/bindings/js/test/integration.test.mjs
+++ b/bindings/js/test/integration.test.mjs
@@ -30,14 +30,22 @@ test("echo roundtrip drives a real session", async () => {
     await su.waitCommand();
     await su.expectText("hello-sdk", { strict: false });
     await su.expectExitCode(0);
+
     const state = await su.state();
+    // Read next to the snapshot it is compared against. The shell draws its
+    // next prompt after the command finishes, which moves the cursor, and
+    // these two calls read it separately: with other calls in between, the
+    // prompt lands between them and they disagree by its width.
+    //
+    // `waitIdle` is not the barrier it looks like here, since the screen is
+    // quiet *because* the prompt has not started, so idle arrives first.
+    assert.deepEqual(await su.getCursor(), state.cursor);
     assert.ok(state.cols > 0);
     assert.match(await su.text(), /hello-sdk/);
     assert.match(await su.getCommand(), /echo hello-sdk/);
     assert.match(await su.getOutput(), /hello-sdk/);
     assert.equal(await su.getExitCode(), 0);
     assert.equal(typeof (await su.getCwd()), "string");
-    assert.deepEqual(await su.getCursor(), state.cursor);
     assert.deepEqual(await su.getSize(), { cols: state.cols, rows: state.rows });
 
     await su.resize(92, 26);


### PR DESCRIPTION
`echo roundtrip drives a real session` fails intermittently on CI, most often on macOS:

```
Expected values to be strictly deep-equal:
+ actual - expected

  {
+   x: 2,
-   x: 0,
    y: 2
  }
```

It compared `getCursor()` against a `state.cursor` captured **five calls earlier**:

```js
const state = await su.state();          // reads the cursor here
assert.ok(state.cols > 0);
assert.match(await su.text(), /hello-sdk/);
assert.match(await su.getCommand(), /echo hello-sdk/);
assert.match(await su.getOutput(), /hello-sdk/);
assert.equal(await su.getExitCode(), 0);
assert.equal(typeof (await su.getCwd()), "string");
assert.deepEqual(await su.getCursor(), state.cursor);   // ...and again here
```

The shell draws its next prompt after the command finishes, and that moves the cursor. A prompt landing between the two reads makes them differ by exactly its width, which is what `x: 0` against `x: 2` is.

Reading them next to each other narrows the window about sixfold, from the five intervening round trips to one:

```
window with the five calls between: 0.29 ms
window when read adjacently:        0.05 ms
```

### This narrows the window rather than closing it

Worth being plain about, since the title says "race".

The window exists because `wait command` falls back to *"the prompt came back and the screen is idle"* when a session has no shell integration, and an idle screen cannot be told apart from a prompt that has not started yet.

My first attempt was `await su.waitIdle()` before the snapshot, which looks like the right barrier and is the idiom already used by the snapshot test in this file. I measured it against a shell with a deliberately slow prompt (`PROMPT_COMMAND='sleep 0.4'`) before trusting it:

```
cursor right after 'wait command': {"x":0,"y":2}
cursor after 'wait idle':          {"x":0,"y":2}    <- no barrier at all
cursor 1s later (settled):         {"x":2,"y":2}
```

`waitIdle` returned with the cursor still at column 0, because the screen was quiet *precisely because* the prompt had not begun. So I dropped it rather than ship a barrier that does nothing, and left a comment so the next person does not reach for it either.

With shell integration working, `wait command` leaves the cursor already settled and there is no window to speak of — so the underlying question is why integration was not in play on the CI runner that failed. That, and two sibling flakes in the Rust lifecycle suite, are tracked in #98.

### Testing

43/43 JS binding tests, three consecutive runs. The change is test-only.
