### PR TITLE
fix: record direct-run exit codes only after the process exits

### DIFF
--- a/bindings/js/test/integration.test.mjs
+++ b/bindings/js/test/integration.test.mjs
@@ -23,6 +23,10 @@ const evalArgs =
   typeof globalThis.Deno === "undefined"
     ? ["-e", "console.log('ready'); setInterval(() => {}, 1000)"]
     : ["eval", "console.log('ready'); setInterval(() => {}, 1000)"];
+const nonzeroExitArgs =
+  typeof globalThis.Deno === "undefined"
+    ? ["-e", "process.exit(7)"]
+    : ["eval", "Deno.exit(7)"];
 
 test("echo roundtrip drives a real session", async () => {
   await withTerminal({ shell }, async (su) => {
@@ -130,6 +134,19 @@ test("a blocking native wait runs off the JS event loop", async () => {
         `blocking wait, got ${ticks}; the event loop appears to have stalled`,
     );
   });
+});
+
+test("repeated direct runtime exits retain their nonzero status", async () => {
+  for (let index = 0; index < 20; index += 1) {
+    const su = TuiTest.ephemeral(`direct-nonzero-${index}`);
+    try {
+      await su.run(process.execPath, nonzeroExitArgs);
+      await su.waitExit({ timeout: 5000 });
+      assert.equal((await su.state()).exited, 7);
+    } finally {
+      await su.closeQuiet();
+    }
+  }
 });
 
 test("concurrent waits do not starve filesystem work", async () => {

--- a/crates/tui-test/src/engine.rs
+++ b/crates/tui-test/src/engine.rs
@@ -1097,23 +1097,29 @@ fn stall_reason(session: &TerminalSession) -> String {
 }
 
 fn wait_exit(session: &TerminalSession, timeout_ms: u64) -> Result<(), TuiTestError> {
-    if poll_until(
-        || {
-            session
+    let start = Instant::now();
+    loop {
+        let (exited, exit_error) = {
+            let state = session
                 .state
                 .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .exited
-                .is_some()
-                || session.cancelled.load(std::sync::atomic::Ordering::Acquire)
-        },
-        timeout_ms,
-    ) {
-        Ok(())
-    } else {
-        Err(TuiTestError::assertion(
-            "wait exit: session still running at timeout",
-        ))
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            (state.exited.is_some(), state.exit_error.clone())
+        };
+        if exited || session.cancelled.load(std::sync::atomic::Ordering::Acquire) {
+            return Ok(());
+        }
+        if let Some(error) = exit_error {
+            return Err(TuiTestError::internal(format!(
+                "wait exit: failed to query process status: {error}"
+            )));
+        }
+        if start.elapsed() >= Duration::from_millis(timeout_ms) {
+            return Err(TuiTestError::assertion(
+                "wait exit: session still running at timeout",
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(POLL_DELAY_MS));
     }
 }
 

--- a/crates/tui-test/src/session.rs
+++ b/crates/tui-test/src/session.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::logger::Logger;
 use crate::profile::Profile;
@@ -24,6 +24,7 @@ pub struct TermState {
     pub last_change: Instant,
     pub awaiting_start: Option<u64>,
     pub exited: Option<i32>,
+    pub exit_error: Option<String>,
 }
 
 pub struct Session {
@@ -38,6 +39,7 @@ pub struct Session {
     recorder: Arc<Mutex<Recorder>>,
     logger: Arc<Logger>,
     _reader: JoinHandle<()>,
+    _process_watcher: JoinHandle<()>,
 }
 
 impl Session {
@@ -85,6 +87,7 @@ impl Session {
             last_change: Instant::now(),
             awaiting_start: None,
             exited: None,
+            exit_error: None,
         }));
         let pty = Arc::new(Mutex::new(pty));
         let cancelled = Arc::new(AtomicBool::new(false));
@@ -105,12 +108,19 @@ impl Session {
         let reader_logger = logger.clone();
         let reader_recorder = recorder.clone();
         let mut reader = reader;
-        let handle = std::thread::spawn(move || {
+        let reader_handle = std::thread::spawn(move || {
             use std::io::Read;
             let mut buf = [0u8; 8192];
             loop {
                 match reader.read(&mut buf) {
-                    Ok(0) | Err(_) => break,
+                    Ok(0) => {
+                        reader_logger.event("pty stream reached EOF");
+                        break;
+                    }
+                    Err(error) => {
+                        reader_logger.event(&format!("pty read failed error={error}"));
+                        break;
+                    }
                     Ok(n) => {
                         reader_logger.read(&buf[..n]);
                         reader_recorder
@@ -135,13 +145,42 @@ impl Session {
                     }
                 }
             }
-            let code = reader_pty.lock().ok().and_then(|mut p| p.try_wait());
-            reader_logger.event(&format!("pty exited code={:?}", code));
-            let mut st = reader_state
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            st.exited = Some(code.unwrap_or(0));
-            st.last_change = Instant::now();
+        });
+
+        let watcher_state = state.clone();
+        let watcher_pty = pty.clone();
+        let watcher_logger = logger.clone();
+        let process_watcher = std::thread::spawn(move || loop {
+            let status = {
+                let mut pty = watcher_pty
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                pty.try_wait()
+            };
+            match status {
+                Ok(Some(code)) => {
+                    watcher_logger.event(&format!("process exited code={code}"));
+                    let mut st = watcher_state
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    st.exited = Some(code);
+                    st.last_change = Instant::now();
+                    break;
+                }
+                Ok(None) => {
+                    std::thread::sleep(Duration::from_millis(crate::config::POLL_DELAY_MS));
+                }
+                Err(error) => {
+                    let error = error.to_string();
+                    watcher_logger.event(&format!("process wait failed error={error}"));
+                    let mut st = watcher_state
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    st.exit_error = Some(error);
+                    st.last_change = Instant::now();
+                    break;
+                }
+            }
         });
 
         logger.event(&format!(
@@ -159,7 +198,8 @@ impl Session {
             cancelled,
             recorder,
             logger,
-            _reader: handle,
+            _reader: reader_handle,
+            _process_watcher: process_watcher,
         })
     }
 

--- a/crates/tui-test/src/terminal/pty.rs
+++ b/crates/tui-test/src/terminal/pty.rs
@@ -120,10 +120,9 @@ impl Pty {
     }
 
     /// Return the exit code if the child has exited.
-    pub fn try_wait(&mut self) -> Option<i32> {
-        match self.child.try_wait() {
-            Ok(Some(status)) => Some(status.exit_code() as i32),
-            _ => None,
-        }
+    pub fn try_wait(&mut self) -> std::io::Result<Option<i32>> {
+        self.child
+            .try_wait()
+            .map(|status| status.map(|status| status.exit_code() as i32))
     }
 }

--- a/crates/tui-test/tests/runtime.rs
+++ b/crates/tui-test/tests/runtime.rs
@@ -1,9 +1,43 @@
+#[cfg(unix)]
+use std::sync::mpsc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use tui_test::{
-    global_registry, ErrorKind, OpenOptions, Operation, OperationResult, SessionRegistry, Timeouts,
+    global_registry, ErrorKind, OpenOptions, Operation, OperationResult, RunOptions, Session,
+    SessionRegistry, Timeouts,
 };
+
+fn run_options(program: &str, args: &[&str]) -> RunOptions {
+    let defaults = OpenOptions::default();
+    RunOptions {
+        program: program.to_string(),
+        args: args.iter().map(|arg| (*arg).to_string()).collect(),
+        profile: defaults.profile,
+        cols: defaults.cols,
+        rows: defaults.rows,
+        cwd: defaults.cwd,
+        env: defaults.env,
+        wait_ready: Some(false),
+        timeouts: defaults.timeouts,
+    }
+}
+
+fn wait_for_exit(session: &Session) {
+    session
+        .execute(Operation::WaitExit {
+            timeout_ms: Some(5_000),
+        })
+        .expect("wait for process exit");
+}
+
+fn process_exit_code(session: &Session) -> Option<i32> {
+    let OperationResult::State(state) = session.execute(Operation::State).expect("read state")
+    else {
+        panic!("unexpected state result");
+    };
+    state.exited
+}
 
 #[test]
 fn named_handles_share_a_process_local_terminal() {
@@ -146,4 +180,114 @@ fn close_all_interrupts_in_flight_waits() {
     registry.close_all();
     assert!(start.elapsed() < Duration::from_secs(2));
     assert_eq!(wait.join().unwrap().unwrap_err().kind, ErrorKind::Assertion);
+}
+
+#[cfg(unix)]
+#[test]
+fn pty_eof_waits_for_the_real_delayed_exit_status() {
+    let session = Session::new(format!("delayed-exit-{}", std::process::id()));
+    session
+        .run(run_options(
+            "sh",
+            &["-c", "exec 0<&- 1>&- 2>&-; sleep 0.4; exit 7"],
+        ))
+        .expect("run delayed exit");
+
+    let start = Instant::now();
+    wait_for_exit(&session);
+
+    assert!(
+        start.elapsed() >= Duration::from_millis(250),
+        "wait exit returned when the PTY reached EOF"
+    );
+    assert_eq!(process_exit_code(&session), Some(7));
+    session.close().expect("close delayed exit");
+}
+
+#[cfg(any(unix, windows))]
+#[test]
+fn direct_zero_exit_status_is_preserved() {
+    let session = Session::new(format!("zero-exit-{}", std::process::id()));
+    #[cfg(unix)]
+    let options = run_options("sh", &["-c", "exit 0"]);
+    #[cfg(windows)]
+    let options = run_options("cmd.exe", &["/C", "exit 0"]);
+
+    session.run(options).expect("run zero exit");
+    wait_for_exit(&session);
+
+    assert_eq!(process_exit_code(&session), Some(0));
+    session.close().expect("close zero exit");
+}
+
+#[cfg(unix)]
+#[test]
+fn signal_derived_exit_status_is_preserved() {
+    let session = Session::new(format!("signal-exit-{}", std::process::id()));
+    session
+        .run(run_options("sh", &["-c", "kill -TERM $$"]))
+        .expect("run signal exit");
+
+    wait_for_exit(&session);
+
+    assert_eq!(process_exit_code(&session), Some(1));
+    session.close().expect("close signal exit");
+}
+
+#[cfg(unix)]
+#[test]
+fn killing_after_pty_eof_does_not_deadlock() {
+    let session = Session::new(format!("kill-after-eof-{}", std::process::id()));
+    session
+        .run(run_options("sh", &["-c", "exec 0<&- 1>&- 2>&-; sleep 5"]))
+        .expect("run process that closes its PTY");
+    std::thread::sleep(Duration::from_millis(300));
+
+    let killer = session.clone();
+    let (sent, received) = mpsc::channel();
+    std::thread::spawn(move || {
+        let result = killer
+            .execute(Operation::Signal {
+                name: "KILL".to_string(),
+            })
+            .map(|_| ())
+            .map_err(|error| error.message);
+        let _ = sent.send(result);
+    });
+
+    match received.recv_timeout(Duration::from_secs(2)) {
+        Ok(result) => result.expect("kill process after PTY EOF"),
+        Err(error) => {
+            std::mem::forget(session);
+            panic!("kill deadlocked after PTY EOF: {error}");
+        }
+    }
+    wait_for_exit(&session);
+    assert_eq!(process_exit_code(&session), Some(1));
+    session.close().expect("close killed process");
+}
+
+#[cfg(unix)]
+#[test]
+fn closing_after_pty_eof_does_not_deadlock() {
+    let session = Session::new(format!("close-after-eof-{}", std::process::id()));
+    session
+        .run(run_options("sh", &["-c", "exec 0<&- 1>&- 2>&-; sleep 5"]))
+        .expect("run process that closes its PTY");
+    std::thread::sleep(Duration::from_millis(300));
+
+    let closer = session.clone();
+    let (sent, received) = mpsc::channel();
+    std::thread::spawn(move || {
+        let result = closer.close().map_err(|error| error.message);
+        let _ = sent.send(result);
+    });
+
+    match received.recv_timeout(Duration::from_secs(2)) {
+        Ok(result) => result.expect("close process after PTY EOF"),
+        Err(error) => {
+            std::mem::forget(session);
+            panic!("close deadlocked after PTY EOF: {error}");
+        }
+    }
 }


### PR DESCRIPTION
we were getting an invalid exit code 0 when the exit status wasn't ready yet