### PR TITLE
feat(terminal): add Ghostty core adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
           rustup default stable
           rustup component add clippy rustfmt
 
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: "0.16.0"
+
       - uses: actions/cache@v4
         with:
           path: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,6 +588,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "int-enum"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366a1634cccc76b4cfd3e7580de9b605e4d93f1edac48d786c1f867c0def495"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "interprocess"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +635,21 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libghostty-vt"
+version = "0.2.1"
+source = "git+https://github.com/Uzaaft/libghostty-rs.git?rev=a28e4ad00d6ba79b98b8cac651ed8976d8500903#a28e4ad00d6ba79b98b8cac651ed8976d8500903"
+dependencies = [
+ "bitflags 2.13.1",
+ "int-enum",
+ "libghostty-vt-sys",
+]
+
+[[package]]
+name = "libghostty-vt-sys"
+version = "0.2.1"
+source = "git+https://github.com/Uzaaft/libghostty-rs.git?rev=a28e4ad00d6ba79b98b8cac651ed8976d8500903#a28e4ad00d6ba79b98b8cac651ed8976d8500903"
 
 [[package]]
 name = "libloading"
@@ -889,6 +916,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
 ]
 
 [[package]]
@@ -1423,6 +1462,7 @@ dependencies = [
  "compact_str",
  "dirs",
  "flate2",
+ "libghostty-vt",
  "portable-pty",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0-beta.1"
 edition = "2021"
-rust-version = "1.88"
+rust-version = "1.90"
 license = "MIT"
 repository = "https://github.com/microsoft/tui-test"
 
@@ -29,6 +29,7 @@ dialoguer = { version = "0.11", default-features = false }
 dirs = "6.0.0"
 flate2 = "1.1.9"
 interprocess = "2.4.2"
+libghostty-vt = { version = "0.2.1", git = "https://github.com/Uzaaft/libghostty-rs.git", rev = "a28e4ad00d6ba79b98b8cac651ed8976d8500903", default-features = false }
 portable-pty = "0.9.0"
 regex = "1.12.4"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ dialoguer = { version = "0.11", default-features = false }
 dirs = "6.0.0"
 flate2 = "1.1.9"
 interprocess = "2.4.2"
-libghostty-vt = { version = "0.2.1", git = "https://github.com/Uzaaft/libghostty-rs.git", rev = "a28e4ad00d6ba79b98b8cac651ed8976d8500903", default-features = false }
+ghostty-vt = { package = "libghostty-vt", version = "0.2.1", git = "https://github.com/Uzaaft/libghostty-rs.git", rev = "a28e4ad00d6ba79b98b8cac651ed8976d8500903", default-features = false }
 portable-pty = "0.9.0"
 regex = "1.12.4"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/tui-test/Cargo.toml
+++ b/crates/tui-test/Cargo.toml
@@ -12,6 +12,10 @@ readme = "../../README.md"
 name = "tui_test"
 path = "src/lib.rs"
 
+[features]
+default = []
+libghostty = ["dep:libghostty-vt"]
+
 [dependencies]
 alacritty_terminal.workspace = true
 anyhow.workspace = true
@@ -19,6 +23,7 @@ bitflags.workspace = true
 compact_str.workspace = true
 dirs.workspace = true
 flate2.workspace = true
+libghostty-vt = { workspace = true, optional = true }
 portable-pty.workspace = true
 regex.workspace = true
 serde.workspace = true

--- a/crates/tui-test/Cargo.toml
+++ b/crates/tui-test/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 
 [features]
 default = []
-libghostty = ["dep:libghostty-vt"]
+ghostty = ["dep:ghostty-vt"]
 
 [dependencies]
 alacritty_terminal.workspace = true
@@ -23,7 +23,7 @@ bitflags.workspace = true
 compact_str.workspace = true
 dirs.workspace = true
 flate2.workspace = true
-libghostty-vt = { workspace = true, optional = true }
+ghostty-vt = { workspace = true, optional = true }
 portable-pty.workspace = true
 regex.workspace = true
 serde.workspace = true

--- a/crates/tui-test/src/terminal/ghostty/core.rs
+++ b/crates/tui-test/src/terminal/ghostty/core.rs
@@ -1,0 +1,403 @@
+//! Single-threaded libghostty terminal and neutral-grid translation.
+#![allow(
+    dead_code,
+    reason = "used by the thread-safe Emulator adapter in the next stack layer"
+)]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use anyhow::{anyhow, Context, Result};
+use compact_str::CompactString;
+use libghostty_vt::error::Error as GhosttyError;
+use libghostty_vt::render::{CellIterator, CursorVisualStyle, RowIterator};
+use libghostty_vt::screen::{Cell as GhosttyCell, CellContentTag, CellWide, GridRef};
+use libghostty_vt::style::{Palette, PaletteIndex, RgbColor, Style, StyleColor, Underline};
+use libghostty_vt::terminal::{
+    ConformanceLevel, DeviceAttributeFeature, DeviceAttributes, DeviceType, Point, PointCoordinate,
+    PrimaryDeviceAttributes, SecondaryDeviceAttributes, TertiaryDeviceAttributes,
+};
+use libghostty_vt::{RenderState, Terminal};
+
+use crate::profile::{xterm_color, ColorSlot, Profile, Rgb};
+use crate::terminal::cell::{Attrs, Color, EmuCell, UnderlineStyle, CONTINUATION};
+use crate::terminal::emu::CursorShape;
+
+fn to_ghostty_rgb(color: Rgb) -> RgbColor {
+    RgbColor {
+        r: color.r,
+        g: color.g,
+        b: color.b,
+    }
+}
+
+fn from_ghostty_rgb(color: RgbColor) -> Rgb {
+    Rgb::new(color.r, color.g, color.b)
+}
+
+fn cell_color(color: StyleColor) -> Option<Color> {
+    match color {
+        StyleColor::None => None,
+        StyleColor::Palette(index) => Some(Color::from_index(index.0)),
+        StyleColor::Rgb(color) => Some(Color::Rgb(color.r, color.g, color.b)),
+    }
+}
+
+fn underline(style: Underline) -> UnderlineStyle {
+    match style {
+        Underline::None => UnderlineStyle::None,
+        Underline::Single => UnderlineStyle::Single,
+        Underline::Double => UnderlineStyle::Double,
+        Underline::Curly => UnderlineStyle::Curly,
+        Underline::Dotted => UnderlineStyle::Dotted,
+        Underline::Dashed => UnderlineStyle::Dashed,
+        _ => UnderlineStyle::Single,
+    }
+}
+
+fn cell_from_ghostty(cell: GhosttyCell, style: Style, graphemes: &[char]) -> Result<EmuCell> {
+    let ch = match cell.wide().context("reading cell width")? {
+        CellWide::SpacerTail => CompactString::const_new(CONTINUATION),
+        CellWide::SpacerHead => CompactString::const_new(" "),
+        CellWide::Narrow | CellWide::Wide if graphemes.is_empty() => CompactString::const_new(" "),
+        CellWide::Narrow | CellWide::Wide => graphemes.iter().collect::<String>().into(),
+    };
+
+    let bg = match cell.content_tag().context("reading cell content")? {
+        CellContentTag::BgColorPalette => Some(Color::from_index(
+            cell.bg_color_palette()
+                .context("reading cell palette background")?
+                .0,
+        )),
+        CellContentTag::BgColorRgb => {
+            let color = cell.bg_color_rgb().context("reading cell RGB background")?;
+            Some(Color::Rgb(color.r, color.g, color.b))
+        }
+        CellContentTag::Codepoint | CellContentTag::CodepointGrapheme => cell_color(style.bg_color),
+    };
+
+    let mut attrs = Attrs::empty();
+    for (enabled, attr) in [
+        (style.bold, Attrs::BOLD),
+        (style.faint, Attrs::DIM),
+        (style.italic, Attrs::ITALIC),
+        (style.inverse, Attrs::INVERSE),
+        (style.invisible, Attrs::INVISIBLE),
+        (style.strikethrough, Attrs::STRIKE),
+        (style.blink, Attrs::BLINK),
+    ] {
+        attrs.set(attr, enabled);
+    }
+
+    Ok(EmuCell {
+        ch,
+        fg: cell_color(style.fg_color),
+        bg,
+        underline: underline(style.underline),
+        underline_color: cell_color(style.underline_color),
+        attrs,
+    })
+}
+
+fn grid_graphemes(grid: &GridRef<'_>) -> Result<Vec<char>> {
+    let mut inline = ['\0'; 8];
+    match grid.graphemes(&mut inline) {
+        Ok(len) => Ok(inline[..len].to_vec()),
+        Err(GhosttyError::OutOfSpace { required }) => {
+            let mut chars = vec!['\0'; required];
+            let len = grid
+                .graphemes(&mut chars)
+                .context("reading cell graphemes")?;
+            chars.truncate(len);
+            Ok(chars)
+        }
+        Err(error) => Err(error).context("reading cell graphemes"),
+    }
+}
+
+fn cell_from_grid(grid: &GridRef<'_>) -> Result<EmuCell> {
+    let cell = grid.cell().context("reading scrollback cell value")?;
+    let graphemes = if matches!(
+        cell.wide().context("reading scrollback cell width")?,
+        CellWide::SpacerHead | CellWide::SpacerTail
+    ) {
+        Vec::new()
+    } else {
+        grid_graphemes(grid)?
+    };
+    cell_from_ghostty(
+        cell,
+        grid.style().context("reading scrollback cell style")?,
+        &graphemes,
+    )
+}
+
+#[derive(Clone)]
+pub(super) struct Frame {
+    pub(super) rows: Vec<Vec<EmuCell>>,
+    pub(super) cursor: (u16, u16),
+    pub(super) cursor_visible: bool,
+    pub(super) cursor_shape: CursorShape,
+}
+
+pub(super) struct GhosttyCore {
+    terminal: Terminal<'static, 'static>,
+    render: RenderState<'static>,
+    row_iter: RowIterator<'static>,
+    cell_iter: CellIterator<'static>,
+    pending: Rc<RefCell<Vec<u8>>>,
+    profile: Profile,
+    frame: Option<Frame>,
+}
+
+impl GhosttyCore {
+    pub(super) fn new(cols: u16, rows: u16, profile: Profile) -> Result<Self> {
+        let mut terminal = Terminal::new(cols.max(1), rows.max(1)).context("creating terminal")?;
+        terminal
+            .resize(cols.max(1), rows.max(1), 1, 1)
+            .context("initializing terminal cell size")?;
+        terminal
+            .set_scrollback_max_lines(Some(profile.scrollback))
+            .context("setting scrollback limit")?;
+
+        terminal
+            .set_default_fg_color(Some(to_ghostty_rgb(profile.colors.foreground)))
+            .context("setting foreground")?
+            .set_default_bg_color(Some(to_ghostty_rgb(profile.colors.background)))
+            .context("setting background")?
+            .set_default_cursor_color(Some(to_ghostty_rgb(profile.colors.cursor)))
+            .context("setting cursor color")?;
+
+        let ansi = profile.colors.ansi();
+        let mut palette = Palette::default();
+        for index in 0u8..=255 {
+            let color = if index < 16 {
+                ansi[index as usize]
+            } else {
+                xterm_color(index)
+            };
+            palette.set(PaletteIndex(index), to_ghostty_rgb(color));
+        }
+        terminal
+            .set_default_color_palette(Some(palette))
+            .context("setting palette")?;
+
+        let pending = Rc::new(RefCell::new(Vec::new()));
+        terminal
+            .on_pty_write({
+                let pending = Rc::clone(&pending);
+                move |_terminal, data| pending.borrow_mut().extend_from_slice(data)
+            })
+            .context("registering PTY replies")?
+            .on_device_attributes(|_terminal| {
+                Some(DeviceAttributes {
+                    primary: PrimaryDeviceAttributes::new(
+                        ConformanceLevel::VT220,
+                        &[DeviceAttributeFeature::ANSI_COLOR],
+                    ),
+                    secondary: SecondaryDeviceAttributes {
+                        device_type: DeviceType::VT220,
+                        firmware_version: 1,
+                        rom_cartridge: 0,
+                    },
+                    tertiary: TertiaryDeviceAttributes { unit_id: 0 },
+                })
+            })
+            .context("registering device attributes")?;
+
+        Ok(Self {
+            terminal,
+            render: RenderState::new().context("creating render state")?,
+            row_iter: RowIterator::new().context("creating row iterator")?,
+            cell_iter: CellIterator::new().context("creating cell iterator")?,
+            pending,
+            profile,
+            frame: None,
+        })
+    }
+
+    pub(super) fn process(&mut self, bytes: &[u8]) {
+        self.terminal.vt_write(bytes);
+        self.frame = None;
+    }
+
+    pub(super) fn take_pending_writes(&mut self) -> Vec<u8> {
+        std::mem::take(&mut *self.pending.borrow_mut())
+    }
+
+    pub(super) fn resize(&mut self, cols: u16, rows: u16) -> Result<()> {
+        self.terminal
+            .resize(cols.max(1), rows.max(1), 1, 1)
+            .context("resizing terminal")?;
+        self.frame = None;
+        Ok(())
+    }
+
+    fn capture(&mut self) -> Result<Frame> {
+        let snapshot = self
+            .render
+            .update(&self.terminal)
+            .context("updating render state")?;
+        let cols = snapshot.cols().context("reading viewport width")?;
+        let rows = snapshot.rows().context("reading viewport height")?;
+        let cursor = (
+            self.terminal
+                .cursor_x()
+                .context("reading cursor column")?
+                .min(cols.saturating_sub(1)),
+            self.terminal
+                .cursor_y()
+                .context("reading cursor row")?
+                .min(rows.saturating_sub(1)),
+        );
+        let cursor_visible = snapshot
+            .cursor_visible()
+            .context("reading cursor visibility")?;
+        let cursor_shape = match snapshot
+            .cursor_visual_style()
+            .context("reading cursor shape")?
+        {
+            CursorVisualStyle::Bar => CursorShape::Bar,
+            CursorVisualStyle::Underline => CursorShape::Underline,
+            _ => CursorShape::Block,
+        };
+
+        let mut output = Vec::with_capacity(rows as usize);
+        let mut row_iter = self
+            .row_iter
+            .update(&snapshot)
+            .context("starting row iteration")?;
+        while let Some(row) = row_iter.next() {
+            let mut output_row = Vec::with_capacity(cols as usize);
+            let mut cells = self
+                .cell_iter
+                .update(row)
+                .context("starting cell iteration")?;
+            while let Some(cell) = cells.next() {
+                let raw = cell.raw_cell().context("reading cell")?;
+                let graphemes = if matches!(
+                    raw.wide().context("reading cell width")?,
+                    CellWide::SpacerHead | CellWide::SpacerTail
+                ) {
+                    Vec::new()
+                } else {
+                    cell.graphemes().context("reading cell graphemes")?
+                };
+                output_row.push(cell_from_ghostty(
+                    raw,
+                    cell.style().context("reading cell style")?,
+                    &graphemes,
+                )?);
+            }
+            if output_row.len() != cols as usize {
+                return Err(anyhow!(
+                    "libghostty returned {} cells for a {cols}-column row",
+                    output_row.len()
+                ));
+            }
+            output.push(output_row);
+        }
+        if output.len() != rows as usize {
+            return Err(anyhow!(
+                "libghostty returned {} rows for a {rows}-row viewport",
+                output.len()
+            ));
+        }
+
+        Ok(Frame {
+            rows: output,
+            cursor,
+            cursor_visible,
+            cursor_shape,
+        })
+    }
+
+    pub(super) fn frame(&mut self) -> Result<&Frame> {
+        if self.frame.is_none() {
+            self.frame = Some(self.capture()?);
+        }
+        Ok(self.frame.as_ref().expect("frame was populated"))
+    }
+
+    pub(super) fn full_rows(&mut self) -> Result<Vec<Vec<EmuCell>>> {
+        let cols = self.terminal.cols().context("reading terminal width")?;
+        let available = self
+            .terminal
+            .scrollback_rows()
+            .context("reading scrollback size")?;
+        let history = available.min(self.profile.scrollback);
+        let mut output = Vec::with_capacity(history + self.terminal.rows()? as usize);
+        for y in available - history..available {
+            let y = u32::try_from(y).context("scrollback exceeds Ghostty coordinates")?;
+            let mut row = Vec::with_capacity(cols as usize);
+            for x in 0..cols {
+                let grid = self
+                    .terminal
+                    .grid_ref(Point::History(PointCoordinate { x, y }))
+                    .context("reading scrollback cell")?;
+                row.push(cell_from_grid(&grid)?);
+            }
+            output.push(row);
+        }
+        output.extend(self.frame()?.rows.clone());
+        Ok(output)
+    }
+
+    pub(super) fn size(&self) -> Result<(u16, u16)> {
+        Ok((self.terminal.cols()?, self.terminal.rows()?))
+    }
+
+    pub(super) fn title(&self) -> Result<Option<String>> {
+        let title = self.terminal.title()?.to_string();
+        Ok((!title.is_empty()).then_some(title))
+    }
+
+    pub(super) fn color(&self, slot: ColorSlot) -> Result<Rgb> {
+        let configured = match slot {
+            ColorSlot::Indexed(index) => self.profile.colors.ansi().get(index as usize).copied(),
+            ColorSlot::Foreground => Some(self.profile.colors.foreground),
+            ColorSlot::Background => Some(self.profile.colors.background),
+            ColorSlot::Cursor => Some(self.profile.colors.cursor),
+        };
+        let current = match slot {
+            ColorSlot::Indexed(index) => Some(
+                self.terminal
+                    .color_palette()
+                    .context("reading palette")?
+                    .get(PaletteIndex(index)),
+            ),
+            ColorSlot::Foreground => self.terminal.fg_color().context("reading foreground")?,
+            ColorSlot::Background => self.terminal.bg_color().context("reading background")?,
+            ColorSlot::Cursor => self
+                .terminal
+                .cursor_color()
+                .context("reading cursor color")?,
+        };
+        current
+            .map(from_ghostty_rgb)
+            .or(configured)
+            .ok_or_else(|| anyhow!("libghostty returned no color for {slot:?}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_wide_cells_into_the_neutral_grid() {
+        let mut core = GhosttyCore::new(5, 3, Profile::default()).unwrap();
+        core.process("abcd你".as_bytes());
+        let rows = &core.frame().unwrap().rows;
+        assert_eq!(rows[0][4].ch, " ");
+        assert_eq!(rows[1][0].ch, "你");
+        assert_eq!(rows[1][1].ch, CONTINUATION);
+    }
+
+    #[test]
+    fn queues_terminal_replies_synchronously() {
+        let mut core = GhosttyCore::new(10, 4, Profile::default()).unwrap();
+        core.process(b"\x1b[3;5H\x1b[6n");
+        assert_eq!(core.take_pending_writes(), b"\x1b[3;5R");
+    }
+}

--- a/crates/tui-test/src/terminal/ghostty/core.rs
+++ b/crates/tui-test/src/terminal/ghostty/core.rs
@@ -1,4 +1,4 @@
-//! Single-threaded libghostty terminal and neutral-grid translation.
+//! Single-threaded Ghostty terminal and neutral-grid translation.
 #![allow(
     dead_code,
     reason = "used by the thread-safe Emulator adapter in the next stack layer"
@@ -9,15 +9,15 @@ use std::rc::Rc;
 
 use anyhow::{anyhow, Context, Result};
 use compact_str::CompactString;
-use libghostty_vt::error::Error as GhosttyError;
-use libghostty_vt::render::{CellIterator, CursorVisualStyle, RowIterator};
-use libghostty_vt::screen::{Cell as GhosttyCell, CellContentTag, CellWide, GridRef};
-use libghostty_vt::style::{Palette, PaletteIndex, RgbColor, Style, StyleColor, Underline};
-use libghostty_vt::terminal::{
+use ghostty_vt::error::Error as GhosttyError;
+use ghostty_vt::render::{CellIterator, CursorVisualStyle, RowIterator};
+use ghostty_vt::screen::{Cell as GhosttyCell, CellContentTag, CellWide, GridRef};
+use ghostty_vt::style::{Palette, PaletteIndex, RgbColor, Style, StyleColor, Underline};
+use ghostty_vt::terminal::{
     ConformanceLevel, DeviceAttributeFeature, DeviceAttributes, DeviceType, Point, PointCoordinate,
     PrimaryDeviceAttributes, SecondaryDeviceAttributes, TertiaryDeviceAttributes,
 };
-use libghostty_vt::{RenderState, Terminal};
+use ghostty_vt::{RenderState, Terminal};
 
 use crate::profile::{xterm_color, ColorSlot, Profile, Rgb};
 use crate::terminal::cell::{Attrs, Color, EmuCell, UnderlineStyle, CONTINUATION};
@@ -291,7 +291,7 @@ impl GhosttyCore {
             }
             if output_row.len() != cols as usize {
                 return Err(anyhow!(
-                    "libghostty returned {} cells for a {cols}-column row",
+                    "Ghostty returned {} cells for a {cols}-column row",
                     output_row.len()
                 ));
             }
@@ -299,7 +299,7 @@ impl GhosttyCore {
         }
         if output.len() != rows as usize {
             return Err(anyhow!(
-                "libghostty returned {} rows for a {rows}-row viewport",
+                "Ghostty returned {} rows for a {rows}-row viewport",
                 output.len()
             ));
         }
@@ -376,7 +376,7 @@ impl GhosttyCore {
         current
             .map(from_ghostty_rgb)
             .or(configured)
-            .ok_or_else(|| anyhow!("libghostty returned no color for {slot:?}"))
+            .ok_or_else(|| anyhow!("Ghostty returned no color for {slot:?}"))
     }
 }
 

--- a/crates/tui-test/src/terminal/ghostty/mod.rs
+++ b/crates/tui-test/src/terminal/ghostty/mod.rs
@@ -1,0 +1,1 @@
+mod core;

--- a/crates/tui-test/src/terminal/mod.rs
+++ b/crates/tui-test/src/terminal/mod.rs
@@ -3,6 +3,8 @@ pub mod cell;
 #[cfg(test)]
 pub mod conformance;
 pub mod emu;
+#[cfg(feature = "libghostty")]
+mod ghostty;
 pub mod integration;
 pub mod locator;
 pub mod pty;

--- a/crates/tui-test/src/terminal/mod.rs
+++ b/crates/tui-test/src/terminal/mod.rs
@@ -3,7 +3,7 @@ pub mod cell;
 #[cfg(test)]
 pub mod conformance;
 pub mod emu;
-#[cfg(feature = "libghostty")]
+#[cfg(feature = "ghostty")]
 mod ghostty;
 pub mod integration;
 pub mod locator;


### PR DESCRIPTION
## Summary

- add the optional `ghostty` Rust feature and pinned Ghostty VT dependency
- translate Ghostty cells, colors, scrollback, cursor state, and PTY replies into the neutral terminal grid
- install Zig 0.16 for all-features CI builds

## Validation

- `cargo clippy -p tui-test-rs --all-targets --features ghostty -- -D warnings`
- `cargo test -p tui-test-rs --features ghostty`

Signed-off-by: cpendery <cpendery@vt.edu>  ---  <sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
