### PR TITLE
docs: explain Ghostty backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ prints a session's effective timeouts.
 
 | Command                                                      | Description                                 |
 | ------------------------------------------------------------ | ------------------------------------------- |
-| `open [--shell S] [--cols N --rows N] [--cwd D] [--env K=V] [--config F] [--profile P] [--timeout-<class> MS]` | Spawn a shell session.                      |
-| `run [--config F] [--profile P] <program> [args...]`         | Spawn a session running a program directly. |
+| `open [--shell S] [--backend B] [--cols N --rows N] [--cwd D] [--env K=V] [--config F] [--profile P] [--timeout-<class> MS]` | Spawn a shell session.                      |
+| `run [--backend B] [--config F] [--profile P] <program> [args...]` | Spawn a session running a program directly. |
 | `sessions`                                                   | List active sessions.                       |
 | `close [--all]`                                              | Close the current session (or all).         |
 | `daemon start` / `daemon status` / `daemon stop --session N \| --all` | Start, inspect, or stop a session's daemon. |
@@ -201,6 +201,45 @@ Each session has its own daemon, so `daemon stop` needs `--session <name>` or
 `--wait-ready` / `--no-wait-ready`. An explicit `--wait-ready` fails (exit 1) if
 no prompt appears; `open`'s implicit wait reports `ready` in its payload either
 way.
+
+### Terminal backends
+
+Choose an emulator per session with `--backend alacritty|ghostty`. Alacritty
+remains the default; `ghostty` uses
+[`libghostty-vt`](https://github.com/Uzaaft/libghostty-rs).
+
+```sh
+tui-test open --backend ghostty
+tui-test run --backend ghostty vim file.txt
+```
+
+Both backends run the same conformance suite and feed the same renderer,
+assertions, and snapshots. Shell semantic-prompt tracking stays on the raw PTY
+byte stream, so command, exit-code, and cwd behavior is backend-independent.
+Ghostty also preserves SGR blink; Alacritty parses blink but cannot report it.
+
+The CLI and published Python/Node native packages include both backends.
+Windows ARM64 artifacts are not currently published because libghostty's
+upstream Zig build does not support that target.
+
+Rust users opt in explicitly:
+
+```sh
+cargo add tui-test-rs --features libghostty
+```
+
+```rust
+use tui_test::{Backend, OpenOptions};
+
+let options = OpenOptions {
+    backend: Backend::Ghostty,
+    ..OpenOptions::default()
+};
+```
+
+Building the `libghostty` feature from source requires Zig 0.16 on `PATH`;
+the dependency builds a pinned Ghostty revision. The default Rust feature set
+continues to build only the Alacritty backend and does not require Zig.
 
 ### Inspection
 
@@ -389,7 +428,7 @@ promises.
 |                                      | tui-test                                        | [tui-use](https://github.com/onesuper/tui-use) | [terminal-use](https://github.com/flipbit03/terminal-use) |
 | ------------------------------------ | ------------------------------------------------ | ---------------------------------------------- | --------------------------------------------------------- |
 | Language                             | Rust                                             | TypeScript/Node                                | Rust                                                      |
-| Emulator                             | alacritty                                        | xterm (headless)                               | alacritty                                                 |
+| Emulator                             | alacritty or Ghostty, per session                | xterm (headless)                               | alacritty                                                 |
 | Shell command tracking               | ✅ command boundaries, exit codes, cwd           | ❌                                             | ❌                                                        |
 | Testing / snapshots                  | ✅ `expect` text / output / exit-code / snapshot | ❌                                             | ❌                                                        |
 | Color & per-cell attributes          | ✅ fg/bg, ANSI-256/hex/rgb, `cells`              | ❌ plain text (+ highlights)                   | via PNG                                                   |

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ way.
 
 Choose an emulator per session with `--backend alacritty|ghostty`. Alacritty
 remains the default; `ghostty` uses
-[`libghostty-vt`](https://github.com/Uzaaft/libghostty-rs).
+[Ghostty's Rust VT bindings](https://github.com/Uzaaft/libghostty-rs).
 
 ```sh
 tui-test open --backend ghostty
@@ -219,13 +219,13 @@ byte stream, so command, exit-code, and cwd behavior is backend-independent.
 Ghostty also preserves SGR blink; Alacritty parses blink but cannot report it.
 
 The CLI and published Python/Node native packages include both backends.
-Windows ARM64 artifacts are not currently published because libghostty's
+Windows ARM64 artifacts are not currently published because Ghostty's
 upstream Zig build does not support that target.
 
 Rust users opt in explicitly:
 
 ```sh
-cargo add tui-test-rs --features libghostty
+cargo add tui-test-rs --features ghostty
 ```
 
 ```rust
@@ -237,7 +237,7 @@ let options = OpenOptions {
 };
 ```
 
-Building the `libghostty` feature from source requires Zig 0.16 on `PATH`;
+Building the `ghostty` feature from source requires Zig 0.16 on `PATH`;
 the dependency builds a pinned Ghostty revision. The default Rust feature set
 continues to build only the Alacritty backend and does not require Zig.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -60,8 +60,8 @@ without parsing text:
 
 | Command                                                                  | Description                                                            |
 | ------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
-| `open [--shell S] [--cols N] [--rows N] [--cwd D] [--env K=V]... [--config F] [--profile P]` | Spawn a shell session (auto-starts the daemon). `--env` is repeatable. |
-| `run [--cols N] [--rows N] [--cwd D] [--env K=V]... [--config F] [--profile P] <program> [args...]` | Spawn a session running a program directly (no shell). |
+| `open [--shell S] [--backend B] [--cols N] [--rows N] [--cwd D] [--env K=V]... [--config F] [--profile P]` | Spawn a shell session (auto-starts the daemon). `--env` is repeatable. |
+| `run [--backend B] [--cols N] [--rows N] [--cwd D] [--env K=V]... [--config F] [--profile P] <program> [args...]` | Spawn a session running a program directly (no shell). |
 | `sessions`                                                               | List active sessions.                                                  |
 | `close [--all]`                                                          | Close the current session (or every session with `--all`).             |
 | `daemon start`                                                           | Start this session's daemon. Most commands start one on demand.        |
@@ -332,10 +332,11 @@ Python and JavaScript methods mirror the cli commands: `open` / `run`, `submit`
 and `getRecording`. The JavaScript client otherwise uses the same names in
 camelCase (`waitCommand`, `expectText`, `getExitCode`, etc.).
 
-The constructors accept a session name plus profile, timeout, and artifact
-options: `TuiTest(session="default", *, timeouts=None, profile=None,
-artifacts=None)` in Python and `new TuiTest(session?, { profile?, timeouts?,
-artifacts? })` in JavaScript. `run` takes the program then its arguments
+The constructors accept a session name plus backend, profile, timeout, and
+artifact options: `TuiTest(session="default", *, backend=None, timeouts=None,
+profile=None, artifacts=None)` in Python and `new TuiTest(session?, {
+backend?, profile?, timeouts?, artifacts? })` in JavaScript. `run` takes the
+program then its arguments
 (`await su.run("vim", "file.txt")` in Python, `await su.run("vim",
 ["file.txt"])` in JavaScript).
 
@@ -343,6 +344,22 @@ Python and JavaScript failures raise typed errors instead of returning exit
 codes, one class per row of the applicable [exit-code table](#exit-codes):
 `ExpectationError` (1), `UsageError` (2), `NoSessionError` (3), and
 `InternalError` (5), all subclasses of `TuiTestError`.
+
+## Terminal backends
+
+`open` and `run` accept `--backend alacritty|ghostty`; Alacritty is the
+default. The Python and JavaScript constructors accept the same canonical
+strings as a client default, and each `open`/`run` can override it.
+
+```sh
+tui-test open --backend ghostty
+tui-test run --backend ghostty -- vim file.txt
+```
+
+Both backends satisfy the same cell-grid contract. Ghostty preserves the blink
+attribute, while Alacritty cannot report it. Command boundaries, exit codes,
+cwd, and captured command output are parsed separately from the raw PTY stream,
+so switching emulators does not change shell integration behavior.
 
 ## Configuration
 

--- a/bindings/js/README.md
+++ b/bindings/js/README.md
@@ -49,14 +49,23 @@ All derive from `TuiTestError` and carry `kind` and `exitCode`. `waitX` and `exp
 
 ## API
 
-`new TuiTest(session?, { profile?, timeouts?, artifacts? })` mirrors the cli: `open` / `run`, `type` / `write`, `submit`, `press` / `keys`, `mouse.click|move|down|up|drag|scroll`, `resize`, `signal` / `kill`, `state`, `text`, `cells`, `getCommand` / `getOutput` / `getExitCode` / `getCwd` / `getCursor` / `getSize` / `getTitle`, `screenshot`, `waitText` / `waitTitle` / `waitIdle` / `waitCommand` / `waitExit` / `waitReady`, `expectText` / `expectTitle` / `expectExitCode` / `expectOutput` / `expectSnapshot`, `close`, and `closeQuiet`.
+`new TuiTest(session?, { backend?, profile?, timeouts?, artifacts? })` mirrors the cli: `open` / `run`, `type` / `write`, `submit`, `press` / `keys`, `mouse.click|move|down|up|drag|scroll`, `resize`, `signal` / `kill`, `state`, `text`, `cells`, `getCommand` / `getOutput` / `getExitCode` / `getCwd` / `getCursor` / `getSize` / `getTitle`, `screenshot`, `waitText` / `waitTitle` / `waitIdle` / `waitCommand` / `waitExit` / `waitReady`, `expectText` / `expectTitle` / `expectExitCode` / `expectOutput` / `expectSnapshot`, `close`, and `closeQuiet`.
 
 Module-level helpers: `sessions()`, `closeAll()`, `getRecording()`, `uniqueSession()`.
 
 `open` and `run` accept
-`{ cols, rows, cwd, env, waitReady, retries, profile, timeouts }`. The
-constructor also accepts `profile` as the default for later opens and runs.
-Profiles are partial; omitted fields use the built-in defaults:
+`{ backend, cols, rows, cwd, env, waitReady, retries, profile, timeouts }`.
+The constructor also accepts `backend` and `profile` as defaults for later
+opens and runs. Backend values are `"alacritty"` (default) and `"ghostty"`:
+
+```js
+const terminal = new TuiTest("work", { backend: "ghostty" });
+await terminal.open();
+await terminal.run("vim", ["file.txt"], { backend: "alacritty" });
+```
+
+The native package includes both emulators. Profiles are partial; omitted
+fields use the built-in defaults:
 
 ```js
 const terminal = new TuiTest("work", {

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -54,13 +54,23 @@ All derive from `TuiTestError`. `wait_*` and `expect_*` raise `ExpectationError`
 
 ## API
 
-`TuiTest(session="default", *, timeouts=None, profile=None, artifacts=None)` mirrors the cli: `open` / `run`, `type` / `write`, `submit`, `press` / `keys`, `mouse.click|move|down|up|drag|scroll`, `resize`, `signal` / `kill`, `state`, `text`, `cells`, `get_command` / `get_output` / `get_exit_code` / `get_cwd` / `get_cursor` / `get_size` / `get_title`, `screenshot`, `wait_text` / `wait_title` / `wait_idle` / `wait_command` / `wait_exit` / `wait_ready`, `expect_text` / `expect_title` / `expect_exit_code` / `expect_output` / `expect_snapshot`, `close`, and `close_quiet`.
+`TuiTest(session="default", *, backend=None, timeouts=None, profile=None, artifacts=None)` mirrors the cli: `open` / `run`, `type` / `write`, `submit`, `press` / `keys`, `mouse.click|move|down|up|drag|scroll`, `resize`, `signal` / `kill`, `state`, `text`, `cells`, `get_command` / `get_output` / `get_exit_code` / `get_cwd` / `get_cursor` / `get_size` / `get_title`, `screenshot`, `wait_text` / `wait_title` / `wait_idle` / `wait_command` / `wait_exit` / `wait_ready`, `expect_text` / `expect_title` / `expect_exit_code` / `expect_output` / `expect_snapshot`, `close`, and `close_quiet`.
 
 Module-level helpers: `sessions()`, `close_all()`, `get_recording()`, `unique_session()`.
 
-`open()` and `run()` accept `wait_ready=`, `retries=`, `profile=`, and
-`timeouts=`. The constructor also accepts `profile=` as the default for later
-opens and runs. Profiles are partial; omitted fields use the built-in defaults:
+`open()` and `run()` accept `backend=`, `wait_ready=`, `retries=`, `profile=`,
+and `timeouts=`. The constructor also accepts `backend=` and `profile=` as
+defaults for later opens and runs. Backend values are `"alacritty"` (default)
+and `"ghostty"`:
+
+```python
+terminal = TuiTest(backend="ghostty")
+await terminal.open()
+await terminal.run("vim", "file.txt", backend="alacritty")
+```
+
+The native package includes both emulators. Profiles are partial; omitted
+fields use the built-in defaults:
 
 ```python
 from tui_test import Colors, Profile, TuiTest


### PR DESCRIPTION
## Summary

- document CLI, Rust, Python, and Node backend selection
- explain feature gating, Zig source-build requirements, and backend behavior
- record the temporary Windows ARM64 release limitation

Signed-off-by: cpendery <cpendery@vt.edu>  ---  <sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
