### PR TITLE
feat: support installing latest beta release

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,16 +112,17 @@ Node is the supported runtime. Bun and Deno compatibility is best effort; Deno r
 macOS / Linux:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/microsoft/tui-test/main/install/install.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/microsoft/tui-test/main/install/install.sh | TUI_TEST_VERSION=beta sh
 ```
 
 Windows PowerShell:
 
 ```powershell
+$env:TUI_TEST_VERSION = "beta"
 irm https://raw.githubusercontent.com/microsoft/tui-test/main/install/install.ps1 | iex
 ```
 
-Use `TUI_TEST_VERSION` to select a specific version or `TUI_TEST_INSTALL_DIR` to select an install location.
+Use `TUI_TEST_VERSION=beta` to select the latest beta, `TUI_TEST_VERSION=latest` to select the latest stable release, or set an exact release tag. If unset, `TUI_TEST_VERSION` defaults to `latest`. Use `TUI_TEST_INSTALL_DIR` to select an install location.
 
 ### download from releases
 

--- a/README.md
+++ b/README.md
@@ -35,16 +35,17 @@ Use the CLI from shell scripts and agent workflows. The Rust, Python, and JavaSc
 ### macOS and Linux
 
 ```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/microsoft/tui-test/main/install/install.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/microsoft/tui-test/main/install/install.sh | TUI_TEST_VERSION=beta sh
 ```
 
 ### Windows
 
 ```powershell
+$env:TUI_TEST_VERSION = "beta"
 irm https://raw.githubusercontent.com/microsoft/tui-test/main/install/install.ps1 | iex
 ```
 
-Use `TUI_TEST_VERSION` to select a specific version or `TUI_TEST_INSTALL_DIR` to select an install location.
+Set `TUI_TEST_VERSION` to install a specific version or `TUI_TEST_INSTALL_DIR` to choose the install location.
 
 ### Release binaries
 

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -37,9 +37,6 @@ elseif ($version -eq "beta") {
         Accept = "application/vnd.github+json"
         "X-GitHub-Api-Version" = "2022-11-28"
     }
-    if (-not [string]::IsNullOrWhiteSpace($token)) {
-        $headers["Authorization"] = "Bearer $token"
-    }
 
     $releases = Invoke-RestMethod `
         -Uri "https://api.github.com/repos/$repository/releases?per_page=100" `

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -24,6 +24,10 @@ switch ($processorArchitecture.ToUpperInvariant()) {
 $target = "$architecture-pc-windows-msvc"
 $asset = "tui-test-$target.zip"
 $version = $env:TUI_TEST_VERSION
+$token = $env:GITHUB_TOKEN
+if ([string]::IsNullOrWhiteSpace($token)) {
+    $token = $env:GH_TOKEN
+}
 
 if ([string]::IsNullOrWhiteSpace($version) -or $version -eq "latest") {
     $releaseUrl = "https://github.com/$repository/releases/latest/download"
@@ -32,6 +36,9 @@ elseif ($version -eq "beta") {
     $headers = @{
         Accept = "application/vnd.github+json"
         "X-GitHub-Api-Version" = "2022-11-28"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($token)) {
+        $headers["Authorization"] = "Bearer $token"
     }
 
     $releases = Invoke-RestMethod `
@@ -69,6 +76,9 @@ try {
         Uri = $downloadUrl
         OutFile = $archivePath
         UseBasicParsing = $true
+    }
+    if (-not [string]::IsNullOrWhiteSpace($token)) {
+        $request.Headers = @{ Authorization = "Bearer $token" }
     }
 
     Write-Host "Downloading tui-test for $target..."

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -24,10 +24,6 @@ switch ($processorArchitecture.ToUpperInvariant()) {
 $target = "$architecture-pc-windows-msvc"
 $asset = "tui-test-$target.zip"
 $version = $env:TUI_TEST_VERSION
-$token = $env:GITHUB_TOKEN
-if ([string]::IsNullOrWhiteSpace($token)) {
-    $token = $env:GH_TOKEN
-}
 
 if ([string]::IsNullOrWhiteSpace($version) -or $version -eq "latest") {
     $releaseUrl = "https://github.com/$repository/releases/latest/download"
@@ -73,9 +69,6 @@ try {
         Uri = $downloadUrl
         OutFile = $archivePath
         UseBasicParsing = $true
-    }
-    if (-not [string]::IsNullOrWhiteSpace($token)) {
-        $request.Headers = @{ Authorization = "Bearer $token" }
     }
 
     Write-Host "Downloading tui-test for $target..."

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -24,19 +24,46 @@ switch ($processorArchitecture.ToUpperInvariant()) {
 $target = "$architecture-pc-windows-msvc"
 $asset = "tui-test-$target.zip"
 $version = $env:TUI_TEST_VERSION
+$token = $env:GITHUB_TOKEN
+if ([string]::IsNullOrWhiteSpace($token)) {
+    $token = $env:GH_TOKEN
+}
 
 if ([string]::IsNullOrWhiteSpace($version) -or $version -eq "latest") {
     $releaseUrl = "https://github.com/$repository/releases/latest/download"
+}
+elseif ($version -eq "beta") {
+    $headers = @{
+        Accept = "application/vnd.github+json"
+        "X-GitHub-Api-Version" = "2022-11-28"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($token)) {
+        $headers["Authorization"] = "Bearer $token"
+    }
+
+    $releases = Invoke-RestMethod `
+        -Uri "https://api.github.com/repos/$repository/releases?per_page=100" `
+        -Headers $headers `
+        -UseBasicParsing
+    $latestBeta = $releases |
+        Where-Object {
+            $_.prerelease -and
+            -not $_.draft -and
+            $_.tag_name -match "^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$"
+        } |
+        Select-Object -First 1
+    if ($null -eq $latestBeta -or [string]::IsNullOrWhiteSpace($latestBeta.tag_name)) {
+        throw "No beta release was found."
+    }
+
+    $version = $latestBeta.tag_name
+    $releaseUrl = "https://github.com/$repository/releases/download/$version"
 }
 else {
     $releaseUrl = "https://github.com/$repository/releases/download/$version"
 }
 
 $downloadUrl = "$releaseUrl/$asset"
-$token = $env:GITHUB_TOKEN
-if ([string]::IsNullOrWhiteSpace($token)) {
-    $token = $env:GH_TOKEN
-}
 
 $tempDir = Join-Path ([IO.Path]::GetTempPath()) ("tui-test-" + [Guid]::NewGuid())
 $archivePath = Join-Path $tempDir $asset

--- a/install/install.sh
+++ b/install/install.sh
@@ -30,6 +30,7 @@ esac
 TARGET="${ARCH}-${OS}"
 ASSET="${BINARY_NAME}-${TARGET}.tar.gz"
 VERSION="${TUI_TEST_VERSION:-latest}"
+TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
 TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t tui-test)"
 ARCHIVE_PATH="${TMP_DIR}/${ASSET}"
 EXTRACT_DIR="${TMP_DIR}/extract"
@@ -44,9 +45,20 @@ download() {
   destination="$2"
 
   if command -v curl >/dev/null 2>&1; then
-    curl --proto '=https' --tlsv1.2 -fsSL "$url" -o "$destination"
+    if [ -n "$TOKEN" ]; then
+      curl --proto '=https' --tlsv1.2 -fsSL \
+        -H "Authorization: Bearer ${TOKEN}" \
+        "$url" -o "$destination"
+    else
+      curl --proto '=https' --tlsv1.2 -fsSL "$url" -o "$destination"
+    fi
   elif command -v wget >/dev/null 2>&1; then
-    wget -q -O "$destination" "$url"
+    if [ -n "$TOKEN" ]; then
+      wget -q --header="Authorization: Bearer ${TOKEN}" \
+        -O "$destination" "$url"
+    else
+      wget -q -O "$destination" "$url"
+    fi
   else
     fail "curl or wget is required."
   fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -30,14 +30,6 @@ esac
 TARGET="${ARCH}-${OS}"
 ASSET="${BINARY_NAME}-${TARGET}.tar.gz"
 VERSION="${TUI_TEST_VERSION:-latest}"
-
-if [ -z "$VERSION" ] || [ "$VERSION" = "latest" ]; then
-  RELEASE_URL="https://github.com/${REPOSITORY}/releases/latest/download"
-else
-  RELEASE_URL="https://github.com/${REPOSITORY}/releases/download/${VERSION}"
-fi
-
-DOWNLOAD_URL="${RELEASE_URL}/${ASSET}"
 TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
 TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t tui-test)"
 ARCHIVE_PATH="${TMP_DIR}/${ASSET}"
@@ -71,6 +63,42 @@ download() {
     fail "curl or wget is required."
   fi
 }
+
+if [ -z "$VERSION" ] || [ "$VERSION" = "latest" ]; then
+  RELEASE_URL="https://github.com/${REPOSITORY}/releases/latest/download"
+elif [ "$VERSION" = "beta" ]; then
+  command -v awk >/dev/null 2>&1 || fail "awk is required to resolve beta releases."
+  RELEASES_PATH="${TMP_DIR}/releases.json"
+  download \
+    "https://api.github.com/repos/${REPOSITORY}/releases?per_page=100" \
+    "$RELEASES_PATH" ||
+    fail "Could not query GitHub releases."
+
+  VERSION="$(
+    awk '
+      /^    "tag_name": "/ {
+        tag = $0
+        sub(/^    "tag_name": "/, "", tag)
+        sub(/",?$/, "", tag)
+        draft = ""
+      }
+      /^    "draft": false,?$/ { draft = "false" }
+      /^    "draft": true,?$/ { draft = "true" }
+      /^    "prerelease": true,?$/ &&
+        draft == "false" &&
+        tag ~ /^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$/ {
+        print tag
+        exit
+      }
+    ' "$RELEASES_PATH"
+  )"
+  [ -n "$VERSION" ] || fail "No beta release was found."
+  RELEASE_URL="https://github.com/${REPOSITORY}/releases/download/${VERSION}"
+else
+  RELEASE_URL="https://github.com/${REPOSITORY}/releases/download/${VERSION}"
+fi
+
+DOWNLOAD_URL="${RELEASE_URL}/${ASSET}"
 
 echo "Downloading tui-test for ${TARGET}..."
 download "$DOWNLOAD_URL" "$ARCHIVE_PATH" ||

--- a/install/install.sh
+++ b/install/install.sh
@@ -43,9 +43,10 @@ trap cleanup EXIT HUP INT TERM
 download() {
   url="$1"
   destination="$2"
+  use_token="${3:-true}"
 
   if command -v curl >/dev/null 2>&1; then
-    if [ -n "$TOKEN" ]; then
+    if [ "$use_token" = "true" ] && [ -n "$TOKEN" ]; then
       curl --proto '=https' --tlsv1.2 -fsSL \
         -H "Authorization: Bearer ${TOKEN}" \
         "$url" -o "$destination"
@@ -53,7 +54,7 @@ download() {
       curl --proto '=https' --tlsv1.2 -fsSL "$url" -o "$destination"
     fi
   elif command -v wget >/dev/null 2>&1; then
-    if [ -n "$TOKEN" ]; then
+    if [ "$use_token" = "true" ] && [ -n "$TOKEN" ]; then
       wget -q --header="Authorization: Bearer ${TOKEN}" \
         -O "$destination" "$url"
     else
@@ -71,7 +72,8 @@ elif [ "$VERSION" = "beta" ]; then
   RELEASES_PATH="${TMP_DIR}/releases.json"
   download \
     "https://api.github.com/repos/${REPOSITORY}/releases?per_page=100" \
-    "$RELEASES_PATH" ||
+    "$RELEASES_PATH" \
+    false ||
     fail "Could not query GitHub releases."
 
   VERSION="$(

--- a/install/install.sh
+++ b/install/install.sh
@@ -30,7 +30,6 @@ esac
 TARGET="${ARCH}-${OS}"
 ASSET="${BINARY_NAME}-${TARGET}.tar.gz"
 VERSION="${TUI_TEST_VERSION:-latest}"
-TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
 TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t tui-test)"
 ARCHIVE_PATH="${TMP_DIR}/${ASSET}"
 EXTRACT_DIR="${TMP_DIR}/extract"
@@ -43,23 +42,11 @@ trap cleanup EXIT HUP INT TERM
 download() {
   url="$1"
   destination="$2"
-  use_token="${3:-true}"
 
   if command -v curl >/dev/null 2>&1; then
-    if [ "$use_token" = "true" ] && [ -n "$TOKEN" ]; then
-      curl --proto '=https' --tlsv1.2 -fsSL \
-        -H "Authorization: Bearer ${TOKEN}" \
-        "$url" -o "$destination"
-    else
-      curl --proto '=https' --tlsv1.2 -fsSL "$url" -o "$destination"
-    fi
+    curl --proto '=https' --tlsv1.2 -fsSL "$url" -o "$destination"
   elif command -v wget >/dev/null 2>&1; then
-    if [ "$use_token" = "true" ] && [ -n "$TOKEN" ]; then
-      wget -q --header="Authorization: Bearer ${TOKEN}" \
-        -O "$destination" "$url"
-    else
-      wget -q -O "$destination" "$url"
-    fi
+    wget -q -O "$destination" "$url"
   else
     fail "curl or wget is required."
   fi
@@ -72,8 +59,7 @@ elif [ "$VERSION" = "beta" ]; then
   RELEASES_PATH="${TMP_DIR}/releases.json"
   download \
     "https://api.github.com/repos/${REPOSITORY}/releases?per_page=100" \
-    "$RELEASES_PATH" \
-    false ||
+    "$RELEASES_PATH" ||
     fail "Could not query GitHub releases."
 
   VERSION="$(


### PR DESCRIPTION
## Summary
- add `TUI_TEST_VERSION=beta` support to the shell and PowerShell installers
- resolve the newest published, non-draft beta through the GitHub Releases API
- use `GITHUB_TOKEN` or `GH_TOKEN` when available, with unauthenticated fallback
- update the install examples to select the beta channel

## Testing
- installed the current beta with `install.sh` using authenticated and anonymous requests
- installed the current beta with `install.ps1` using authenticated and anonymous requests
- checked shell and PowerShell syntax