### PR TITLE
fix: stabilize snapshots after resize

### DIFF
--- a/crates/tui-test-cli/tests/session_lifecycle.rs
+++ b/crates/tui-test-cli/tests/session_lifecycle.rs
@@ -1549,6 +1549,9 @@ fn terminal_backends_match_end_to_end_for_cells_state_and_snapshots() {
         // Exercise snapshot round-tripping, but compare its visual content
         // instead of reusing one backend's row layout as the shared baseline.
         sandbox.ok(&["resize", "16", "4"]);
+        // ConPTY asynchronously redraws its screen after a resize. Wait for
+        // that redraw so both halves of the snapshot round-trip see one frame.
+        sandbox.ok(&["wait", "idle", "--timeout", "5000"]);
         sandbox.ok_in(
             Some(&sandbox.home),
             &[

--- a/crates/tui-test/src/session.rs
+++ b/crates/tui-test/src/session.rs
@@ -460,6 +460,7 @@ fn resize_emulator_and_record(state: &Mutex<TermState>, recorder: &Recorder, col
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     recorder.on_resize(cols, rows);
     state.emu.resize(cols, rows);
+    state.last_change = Instant::now();
 }
 
 fn drain_reader_and_recorder(reader: &mut Option<JoinHandle<()>>, recorder: &mut Recorder) {
@@ -592,7 +593,7 @@ mod tests {
     use std::time::Duration;
 
     #[test]
-    fn resize_is_queued_after_output_already_processing_at_the_old_size() {
+    fn resize_is_queued_after_old_output_and_starts_a_new_idle_period() {
         let path = test_path("resize-order");
         let mut recorder = Recorder::create(path.clone(), 1, 1, &[], Arc::new(Logger::disabled()));
         let state = Arc::new(Mutex::new(TermState {
@@ -621,7 +622,16 @@ mod tests {
             release_tx.send(()).unwrap();
         });
 
+        let resize_started = Instant::now();
         resize_emulator_and_record(&state, &recorder, 2, 1);
+        assert!(
+            state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .last_change
+                >= resize_started,
+            "wait idle must not reuse the quiet period from before a resize"
+        );
         release.join().unwrap();
         output.join().unwrap();
         recorder.capture().on_data(b"new-size-output");


### PR DESCRIPTION
## Summary
- mark emulator resizes as terminal activity so `wait idle` starts a fresh quiet period
- wait for asynchronous ConPTY redraws before round-tripping resized snapshots
- extend resize-ordering coverage to prevent the idle-clock regression

## Root cause
On Windows, ConPTY can emit a full-screen redraw immediately after the emulator resize returns. The snapshot test could write its baseline before that redraw and compare it afterward, observing two valid row layouts from different frames.

Failure: https://github.com/microsoft/tui-test/actions/runs/32505599633/job/96844938742

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -p tui-test-rs -p tui-test-cli --all-targets --all-features -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- backend parity regression test passed 30 consecutive runs