### PR TITLE
feat(input): route key encoding to the backend, honor DECCKM, and report ghostty's keyboard modes

### DIFF
--- a/crates/tui-test/assets/xtermjs/shim.js
+++ b/crates/tui-test/assets/xtermjs/shim.js
@@ -360,6 +360,11 @@ globalThis.__boot = function (cols, rows, scrollback, base) {
     // color *modes* packed into `flags` alongside the SGR booleans: a raw
     // color of 1 is palette slot 1 or the RGB triple #000001 depending on its
     // mode, so the mode has to travel with it.
+    // DECCKM. xterm.js exposes the mode set on the public `modes` object.
+    cursorKeyApplication: function () {
+      return term.modes.applicationCursorKeysMode ? 1 : 0;
+    },
+
     pack: function (start, end) {
       var buf = term.buffer.active, cols = term.cols;
       var chars = [], meta = [];

--- a/crates/tui-test/src/engine.rs
+++ b/crates/tui-test/src/engine.rs
@@ -1115,18 +1115,45 @@ fn key_action(
     tokens: Vec<String>,
     action: crate::api::KeyAction,
 ) -> Result<(), TuiTestError> {
-    let keyboard_mode = session
-        .state
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .emu
-        .keyboard_mode();
-    let sequence = keys::tokens_to_seq_for_action_with_mode(&tokens, action, keyboard_mode)
-        .map_err(|error| TuiTestError::usage(error.to_string()))?;
+    // A backend with its own key encoder is preferred, per token, because it
+    // reads terminal state the shared encoder does not model: ghostty's
+    // applies keypad application mode, `modifyOtherKeys`, and the alt-escape
+    // prefix. A backend that has no encoder, or cannot express a particular
+    // event, answers `None` and that token falls back.
+    let mut sequence: Vec<u8> = Vec::new();
+    {
+        let state = session
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let modes = keys::InputModes {
+            keyboard: state.emu.keyboard_mode(),
+            cursor_key_application: state.emu.cursor_key_application(),
+        };
+        for token in &tokens {
+            let presses = keys::token_to_presses(token, action)
+                .map_err(|error| TuiTestError::usage(error.to_string()))?;
+            let encoded: Option<Vec<Vec<u8>>> = presses
+                .iter()
+                .map(|press| state.emu.encode_key(press))
+                .collect();
+            match encoded {
+                // All or nothing per token: a token half-encoded by the
+                // backend and half by the fallback would interleave two
+                // encodings of the same keypress.
+                Some(parts) => sequence.extend(parts.concat()),
+                None => {
+                    let text = keys::token_to_seq_for_action_with_mode(token, action, modes)
+                        .map_err(|error| TuiTestError::usage(error.to_string()))?;
+                    sequence.extend_from_slice(text.as_bytes());
+                }
+            }
+        }
+    }
     if sequence.is_empty() {
         Ok(())
     } else {
-        act(session.write(sequence.as_bytes()))
+        act(session.write(&sequence))
     }
 }
 

--- a/crates/tui-test/src/input/keys.rs
+++ b/crates/tui-test/src/input/keys.rs
@@ -1,13 +1,39 @@
 //! Key-name and key-event to terminal input sequence mapping.
 
 use crate::api::KeyAction;
+use compact_str::{CompactString, ToCompactString};
+
 use crate::terminal::emu::KeyboardMode;
+
+/// The terminal state key encoding depends on.
+///
+/// Grouped rather than passed as separate arguments because encoding branches
+/// on all of it at once and the set grows: DECCKM joined the Kitty flags here
+/// once arrows had to be able to come out as `SS3 A`.
+///
+/// Public entry points take `impl Into<InputModes>`, so a caller that only has
+/// Kitty flags can still pass them directly.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct InputModes {
+    pub keyboard: KeyboardMode,
+    /// `DECCKM`: the child expects `SS3 A` from the up arrow, not `CSI A`.
+    pub cursor_key_application: bool,
+}
+
+impl From<KeyboardMode> for InputModes {
+    fn from(keyboard: KeyboardMode) -> Self {
+        Self {
+            keyboard,
+            cursor_key_application: false,
+        }
+    }
+}
 
 const ESC: &str = "\u{1b}";
 const CSI: &str = "\u{1b}[";
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-enum KeyEventKind {
+pub enum KeyEventKind {
     #[default]
     Press,
     Repeat,
@@ -24,14 +50,14 @@ impl KeyEventKind {
     }
 }
 
-#[derive(Default, Clone, Copy)]
-struct Mods {
-    ctrl: bool,
-    alt: bool,
-    shift: bool,
-    super_key: bool,
-    hyper: bool,
-    meta: bool,
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Mods {
+    pub ctrl: bool,
+    pub alt: bool,
+    pub shift: bool,
+    pub super_key: bool,
+    pub hyper: bool,
+    pub meta: bool,
 }
 
 impl Mods {
@@ -43,7 +69,7 @@ impl Mods {
         self.ctrl || self.alt || self.super_key || self.hyper || self.meta
     }
 
-    fn has_kitty_only_modifier(self) -> bool {
+    pub fn has_kitty_only_modifier(self) -> bool {
         self.super_key || self.hyper || self.meta
     }
 
@@ -95,22 +121,28 @@ fn parse_token(token: &str) -> anyhow::Result<ParsedToken<'_>> {
     Ok(ParsedToken { key, mods })
 }
 
-fn kitty_sequences(mode: KeyboardMode) -> bool {
-    mode.intersects(
+fn kitty_sequences(mode: InputModes) -> bool {
+    mode.keyboard.intersects(
         KeyboardMode::DISAMBIGUATE_ESC_CODES
             | KeyboardMode::REPORT_EVENT_TYPES
             | KeyboardMode::REPORT_ALL_KEYS_AS_ESC,
     )
 }
 
-fn named(key: &str, mods: Mods, event: KeyEventKind, mode: KeyboardMode) -> Option<String> {
+fn named(key: &str, mods: Mods, event: KeyEventKind, mode: InputModes) -> Option<String> {
+    // `DECCKM` swaps the cursor keys' introducer from `CSI` to `SS3`, and it
+    // reaches exactly the keys `CSI ... A-D`, `H`, and `F` spell: the arrows
+    // plus Home and End. Only an unmodified press changes, which is already
+    // what `ss3_unmodified` means for F1-F4, so it reuses that rather than
+    // adding a second rule that could drift from it.
+    let ss3 = mode.cursor_key_application;
     let sequence = match key.to_ascii_lowercase().as_str() {
-        "home" => navigation(None, 'H', false, mods, event, mode),
-        "end" => navigation(None, 'F', false, mods, event, mode),
-        "up" => navigation(None, 'A', false, mods, event, mode),
-        "down" => navigation(None, 'B', false, mods, event, mode),
-        "right" => navigation(None, 'C', false, mods, event, mode),
-        "left" => navigation(None, 'D', false, mods, event, mode),
+        "home" => navigation(None, 'H', ss3, mods, event, mode),
+        "end" => navigation(None, 'F', ss3, mods, event, mode),
+        "up" => navigation(None, 'A', ss3, mods, event, mode),
+        "down" => navigation(None, 'B', ss3, mods, event, mode),
+        "right" => navigation(None, 'C', ss3, mods, event, mode),
+        "left" => navigation(None, 'D', ss3, mods, event, mode),
         "pageup" => navigation(Some(5), '~', false, mods, event, mode),
         "pagedown" => navigation(Some(6), '~', false, mods, event, mode),
         "insert" => navigation(Some(2), '~', false, mods, event, mode),
@@ -144,9 +176,9 @@ fn navigation(
     ss3_unmodified: bool,
     mods: Mods,
     event: KeyEventKind,
-    mode: KeyboardMode,
+    mode: InputModes,
 ) -> String {
-    let report_events = mode.contains(KeyboardMode::REPORT_EVENT_TYPES);
+    let report_events = mode.keyboard.contains(KeyboardMode::REPORT_EVENT_TYPES);
     if event == KeyEventKind::Release && !report_events {
         return String::new();
     }
@@ -198,14 +230,14 @@ impl ControlKey {
     }
 }
 
-fn control_key(key: ControlKey, mods: Mods, event: KeyEventKind, mode: KeyboardMode) -> String {
-    let report_events = mode.contains(KeyboardMode::REPORT_EVENT_TYPES);
-    let report_all = mode.contains(KeyboardMode::REPORT_ALL_KEYS_AS_ESC);
+fn control_key(key: ControlKey, mods: Mods, event: KeyEventKind, mode: InputModes) -> String {
+    let report_events = mode.keyboard.contains(KeyboardMode::REPORT_EVENT_TYPES);
+    let report_all = mode.keyboard.contains(KeyboardMode::REPORT_ALL_KEYS_AS_ESC);
     if event == KeyEventKind::Release && !report_events {
         return String::new();
     }
 
-    let disambiguate = mode.contains(KeyboardMode::DISAMBIGUATE_ESC_CODES);
+    let disambiguate = mode.keyboard.contains(KeyboardMode::DISAMBIGUATE_ESC_CODES);
     if matches!(key, ControlKey::Escape)
         && event == KeyEventKind::Press
         && !mods.any()
@@ -414,8 +446,8 @@ fn literal_key(ch: char) -> (char, Mods) {
     }
 }
 
-fn character(ch: char, mods: Mods, event: KeyEventKind, mode: KeyboardMode) -> String {
-    let report_events = mode.contains(KeyboardMode::REPORT_EVENT_TYPES);
+fn character(ch: char, mods: Mods, event: KeyEventKind, mode: InputModes) -> String {
+    let report_events = mode.keyboard.contains(KeyboardMode::REPORT_EVENT_TYPES);
     if event == KeyEventKind::Release && !report_events {
         return String::new();
     }
@@ -424,9 +456,10 @@ fn character(ch: char, mods: Mods, event: KeyEventKind, mode: KeyboardMode) -> S
     // Text-producing keys need report-all mode before repeat/release events
     // can be represented separately from their UTF-8 text.
     let produces_text = !mods.disambiguates_character();
-    let escape_encoded = mode.contains(KeyboardMode::REPORT_ALL_KEYS_AS_ESC)
+    let escape_encoded = mode.keyboard.contains(KeyboardMode::REPORT_ALL_KEYS_AS_ESC)
         || (report_events && event != KeyEventKind::Press && !produces_text)
-        || (mode.contains(KeyboardMode::DISAMBIGUATE_ESC_CODES) && mods.disambiguates_character())
+        || (mode.keyboard.contains(KeyboardMode::DISAMBIGUATE_ESC_CODES)
+            && mods.disambiguates_character())
         || legacy.is_none();
     if event == KeyEventKind::Release && !escape_encoded {
         return String::new();
@@ -436,12 +469,14 @@ fn character(ch: char, mods: Mods, event: KeyEventKind, mode: KeyboardMode) -> S
     }
 
     let (base, text) = key_chars(ch, mods);
-    let payload =
-        if mode.contains(KeyboardMode::REPORT_ALTERNATE_KEYS) && mods.shift && text != base {
-            format!("{}:{}", base as u32, text as u32)
-        } else {
-            (base as u32).to_string()
-        };
+    let payload = if mode.keyboard.contains(KeyboardMode::REPORT_ALTERNATE_KEYS)
+        && mods.shift
+        && text != base
+    {
+        format!("{}:{}", base as u32, text as u32)
+    } else {
+        (base as u32).to_string()
+    };
     let associated = associated_text(ch, mods);
     kitty_u(payload, mods, event, mode, associated.as_deref())
 }
@@ -450,15 +485,16 @@ fn kitty_u(
     payload: String,
     mods: Mods,
     event: KeyEventKind,
-    mode: KeyboardMode,
+    mode: InputModes,
     associated_text: Option<&str>,
 ) -> String {
     let event_code = mode
+        .keyboard
         .contains(KeyboardMode::REPORT_EVENT_TYPES)
         .then(|| event.code())
         .flatten();
     let associated_text = associated_text.filter(|text| {
-        mode.contains(KeyboardMode::REPORT_ASSOCIATED_TEXT)
+        mode.keyboard.contains(KeyboardMode::REPORT_ASSOCIATED_TEXT)
             && event != KeyEventKind::Release
             && text.chars().all(|ch| !is_control(ch))
     });
@@ -496,12 +532,117 @@ fn action_events(action: KeyAction) -> &'static [KeyEventKind] {
     }
 }
 
+/// One key event, as the encoder sees it before any escape sequence exists.
+///
+/// This is the hand-off point for [`crate::terminal::emu::Emulator::encode_key`]:
+/// a backend with its own encoder is given this rather than a token, so it
+/// never has to know tui-test's spelling of a key name.
+#[derive(Debug, Clone)]
+pub struct KeyPress {
+    /// The key's name. Either one of the named keys, lowercased (`"up"`,
+    /// `"f5"`, `"enter"`), or the single *unshifted* character the key sits
+    /// on, so `!` arrives as `"1"` with `mods.shift`.
+    ///
+    /// Owned rather than borrowed: a key name is a handful of bytes, and the
+    /// ghostty backend has to move it to the thread that owns its terminal.
+    pub key: CompactString,
+    pub mods: Mods,
+    pub event: KeyEventKind,
+    /// The text this key produces, for the keys that produce any.
+    ///
+    /// Carried rather than derived because deriving it needs a keyboard
+    /// layout: `Shift+1` is `!` on a US layout and `"` on a UK one. tui-test
+    /// works in the US layout its token vocabulary already assumes, and a
+    /// backend encoder is handed the answer rather than asked to guess.
+    pub text: Option<CompactString>,
+}
+
+/// Split a token into the key events an action produces.
+///
+/// Exposed so a caller routing to a backend encoder can hand it the same
+/// events the shared encoder would have encoded, rather than re-parsing the
+/// token itself and drifting from this one.
+pub fn token_to_presses(token: &str, action: KeyAction) -> anyhow::Result<Vec<KeyPress>> {
+    if token.is_empty() {
+        return Ok(Vec::new());
+    }
+    let parsed = parse_token(token)?;
+    // A multi-character token that is not a named key is a literal string,
+    // typed one character at a time; the backend encoder is handed each
+    // character as its own press.
+    let is_named = named(
+        parsed.key,
+        parsed.mods,
+        KeyEventKind::Press,
+        InputModes::default(),
+    )
+    .is_some();
+
+    // Mirrors how `token_to_seq_for_action_with_mode` classifies the same
+    // token, so both encoders are handed the same events. A named key keeps
+    // its name; a character is reduced to the key it sits on plus the text it
+    // produces, which is what an encoder needs to know.
+    let keys: Vec<(CompactString, Mods, Option<CompactString>)> = if is_named {
+        let text = (parsed.key.eq_ignore_ascii_case("space")).then(|| " ".into());
+        vec![(parsed.key.to_ascii_lowercase().into(), parsed.mods, text)]
+    } else if parsed.key.chars().count() == 1 {
+        let ch = parsed.key.chars().next().expect("one character");
+        let (key, mods) = if parsed.mods.any() {
+            (ch, parsed.mods)
+        } else {
+            literal_key(ch)
+        };
+        vec![(
+            key.to_compact_string(),
+            mods,
+            Some(produced_text(key, mods)),
+        )]
+    } else if parsed.mods.any() {
+        anyhow::bail!("invalid key: '{}'", parsed.key);
+    } else {
+        parsed
+            .key
+            .chars()
+            .map(|ch| {
+                let (key, mods) = literal_key(ch);
+                (
+                    key.to_compact_string(),
+                    mods,
+                    Some(produced_text(key, mods)),
+                )
+            })
+            .collect()
+    };
+
+    let mut out = Vec::new();
+    for (key, mods, text) in keys {
+        for &event in action_events(action) {
+            out.push(KeyPress {
+                key: key.clone(),
+                mods,
+                event,
+                text: text.clone(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// The text an unshifted key plus its modifiers actually produces.
+fn produced_text(key: char, mods: Mods) -> CompactString {
+    match mods.shift.then(|| shift_ascii(key)).flatten() {
+        Some(shifted) => shifted.to_compact_string(),
+        None => key.to_compact_string(),
+    }
+}
+
 /// Translate one key token and action using the active terminal keyboard mode.
 pub fn token_to_seq_for_action_with_mode(
     token: &str,
     action: KeyAction,
-    mode: KeyboardMode,
+    mode: impl Into<InputModes>,
 ) -> anyhow::Result<String> {
+    let mode = mode.into();
     if token.is_empty() {
         return Ok(String::new());
     }
@@ -551,7 +692,7 @@ pub fn token_to_seq_for_action_with_mode(
 }
 
 /// Translate one key-down event using the active terminal keyboard mode.
-pub fn token_to_seq_with_mode(token: &str, mode: KeyboardMode) -> anyhow::Result<String> {
+pub fn token_to_seq_with_mode(token: &str, mode: impl Into<InputModes>) -> anyhow::Result<String> {
     token_to_seq_for_action_with_mode(token, KeyAction::Down, mode)
 }
 
@@ -559,8 +700,9 @@ pub fn token_to_seq_with_mode(token: &str, mode: KeyboardMode) -> anyhow::Result
 pub fn tokens_to_seq_for_action_with_mode(
     tokens: &[String],
     action: KeyAction,
-    mode: KeyboardMode,
+    mode: impl Into<InputModes>,
 ) -> anyhow::Result<String> {
+    let mode = mode.into();
     let mut out = String::new();
     for token in tokens {
         out.push_str(&token_to_seq_for_action_with_mode(token, action, mode)?);
@@ -569,7 +711,10 @@ pub fn tokens_to_seq_for_action_with_mode(
 }
 
 /// Translate key-down tokens using the active terminal keyboard mode.
-pub fn tokens_to_seq_with_mode(tokens: &[String], mode: KeyboardMode) -> anyhow::Result<String> {
+pub fn tokens_to_seq_with_mode(
+    tokens: &[String],
+    mode: impl Into<InputModes>,
+) -> anyhow::Result<String> {
     tokens_to_seq_for_action_with_mode(tokens, KeyAction::Down, mode)
 }
 
@@ -584,6 +729,95 @@ pub fn tokens_to_seq(tokens: &[String]) -> anyhow::Result<String> {
 }
 
 #[cfg(test)]
+mod decckm_tests {
+    use super::*;
+
+    fn app(token: &str) -> String {
+        token_to_seq_with_mode(
+            token,
+            InputModes {
+                keyboard: KeyboardMode::empty(),
+                cursor_key_application: true,
+            },
+        )
+        .unwrap()
+    }
+
+    /// `CSI ?1h` swaps the cursor keys onto `SS3`. readline, vim, and less all
+    /// set it, so a session that kept sending `CSI A` was sending something no
+    /// real terminal sends once the child had asked.
+    #[test]
+    fn application_cursor_keys_use_ss3() {
+        for (token, expected) in [
+            ("Up", "\x1bOA"),
+            ("Down", "\x1bOB"),
+            ("Right", "\x1bOC"),
+            ("Left", "\x1bOD"),
+            ("Home", "\x1bOH"),
+            ("End", "\x1bOF"),
+        ] {
+            assert_eq!(app(token), expected, "{token} in application mode");
+        }
+    }
+
+    /// Without the mode the cursor keys keep the `CSI` form, so this changes
+    /// nothing for a child that never asked.
+    #[test]
+    fn normal_cursor_keys_are_unchanged() {
+        for (token, expected) in [
+            ("Up", "\x1b[A"),
+            ("Down", "\x1b[B"),
+            ("Right", "\x1b[C"),
+            ("Left", "\x1b[D"),
+            ("Home", "\x1b[H"),
+            ("End", "\x1b[F"),
+        ] {
+            assert_eq!(token_to_seq(token).unwrap(), expected, "{token} normally");
+        }
+    }
+
+    /// A modified cursor key carries its modifier parameter, which `SS3` has
+    /// nowhere to put, so it stays `CSI` in application mode too.
+    #[test]
+    fn a_modified_cursor_key_stays_csi() {
+        let modes = InputModes {
+            keyboard: KeyboardMode::empty(),
+            cursor_key_application: true,
+        };
+        assert_eq!(
+            token_to_seq_with_mode("Ctrl+Up", modes).unwrap(),
+            "\x1b[1;5A"
+        );
+        assert_eq!(
+            token_to_seq_with_mode("Shift+Home", modes).unwrap(),
+            "\x1b[1;2H"
+        );
+    }
+
+    /// The Kitty protocol replaces the legacy encoding outright, and its
+    /// cursor keys are `CSI` with a parameter, so `DECCKM` does not apply.
+    #[test]
+    fn kitty_encoding_outranks_application_mode() {
+        let modes = InputModes {
+            keyboard: KeyboardMode::DISAMBIGUATE_ESC_CODES,
+            cursor_key_application: true,
+        };
+        assert_eq!(token_to_seq_with_mode("Up", modes).unwrap(), "\x1b[A");
+    }
+
+    /// Keys that are not cursor keys are untouched, including the function
+    /// keys that have their own unrelated `SS3` form.
+    #[test]
+    fn application_mode_reaches_only_the_cursor_keys() {
+        assert_eq!(app("PageUp"), "\x1b[5~");
+        assert_eq!(app("Delete"), "\x1b[3~");
+        assert_eq!(app("F1"), "\x1bOP", "F1 is SS3 either way");
+        assert_eq!(app("F5"), "\x1b[15~");
+        assert_eq!(app("a"), "a");
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -591,7 +825,11 @@ mod tests {
         token_to_seq(token)
     }
 
-    fn action_seq(token: &str, action: KeyAction, mode: KeyboardMode) -> anyhow::Result<String> {
+    fn action_seq(
+        token: &str,
+        action: KeyAction,
+        mode: impl Into<InputModes>,
+    ) -> anyhow::Result<String> {
         token_to_seq_for_action_with_mode(token, action, mode)
     }
 
@@ -785,7 +1023,14 @@ mod tests {
         );
     }
 
-    fn assert_events(mode: KeyboardMode, key: &str, press: &str, repeat: &str, release: &str) {
+    fn assert_events(
+        mode: impl Into<InputModes>,
+        key: &str,
+        press: &str,
+        repeat: &str,
+        release: &str,
+    ) {
+        let mode = mode.into();
         assert_eq!(token_to_seq_with_mode(key, mode).unwrap(), press, "{key}");
         assert_eq!(
             action_seq(key, KeyAction::Repeat, mode).unwrap(),

--- a/crates/tui-test/src/input/keys.rs
+++ b/crates/tui-test/src/input/keys.rs
@@ -256,6 +256,12 @@ fn control_key(key: ControlKey, mods: Mods, event: KeyEventKind, mode: InputMode
         };
     }
 
+    // Enter, Tab and Backspace report no release until report-all is on, so
+    // that a program leaving event reporting set does not stop the user
+    // typing `reset` at a shell prompt. Kitty gates this on the chord rather
+    // than the key, so a modified one is still reported: `shift+tab` releases
+    // as `CSI 9;2:3u` while `tab` releases as nothing. Ghostty exempts the
+    // key whatever the modifiers, which the oracle records as a divergence.
     let safety_path = key.is_safety_key() && !report_all && !mods.any();
     if safety_path {
         return if event == KeyEventKind::Release {
@@ -453,11 +459,19 @@ fn character(ch: char, mods: Mods, event: KeyEventKind, mode: InputModes) -> Str
     }
 
     let legacy = legacy_character(ch, mods);
-    // Text-producing keys need report-all mode before repeat/release events
-    // can be represented separately from their UTF-8 text.
     let produces_text = !mods.disambiguates_character();
+    // A release has no text to carry — the text belongs to the press — so
+    // under event reporting an escape code is its only representation. A
+    // repeat is different: holding a key down means more text, so it stays
+    // text and is indistinguishable from a press, which is the point.
+    //
+    // The spec exempts Enter, Tab and Backspace from release reporting so
+    // that `reset` stays typable at a shell prompt; those take the safety-key
+    // path in `functional` rather than this one.
     let escape_encoded = mode.keyboard.contains(KeyboardMode::REPORT_ALL_KEYS_AS_ESC)
-        || (report_events && event != KeyEventKind::Press && !produces_text)
+        || (report_events
+            && (event == KeyEventKind::Release
+                || (event == KeyEventKind::Repeat && !produces_text)))
         || (mode.keyboard.contains(KeyboardMode::DISAMBIGUATE_ESC_CODES)
             && mods.disambiguates_character())
         || legacy.is_none();
@@ -1047,7 +1061,9 @@ mod tests {
     #[test]
     fn explicit_events_use_csi_u_when_event_reporting_is_enabled() {
         let events = KeyboardMode::REPORT_EVENT_TYPES;
-        assert_events(events, "a", "a", "a", "");
+        // A release carries no text, so it is reported even though the press
+        // and repeat of the same key are plain text.
+        assert_events(events, "a", "a", "a", "\u{1b}[97;1:3u");
         assert_events(
             events,
             "Ctrl+a",
@@ -1059,7 +1075,7 @@ mod tests {
         assert_events(events, "Enter", "\r", "\r", "");
 
         let disambiguated_events = events | KeyboardMode::DISAMBIGUATE_ESC_CODES;
-        assert_events(disambiguated_events, "a", "a", "a", "");
+        assert_events(disambiguated_events, "a", "a", "a", "\u{1b}[97;1:3u");
         assert_events(
             disambiguated_events,
             "Ctrl+a",
@@ -1176,7 +1192,7 @@ mod tests {
     }
 
     #[test]
-    fn press_reports_release_only_when_requested_and_representable() {
+    fn press_reports_release_only_when_event_types_are_requested() {
         assert_eq!(
             action_seq("Up", KeyAction::Press, KeyboardMode::empty()).unwrap(),
             "\u{1b}[A"
@@ -1187,7 +1203,10 @@ mod tests {
             action_seq("Up", KeyAction::Press, events).unwrap(),
             "\u{1b}[A\u{1b}[1;1:3A"
         );
-        assert_eq!(action_seq("a", KeyAction::Press, events).unwrap(), "a");
+        assert_eq!(
+            action_seq("a", KeyAction::Press, events).unwrap(),
+            "a\u{1b}[97;1:3u"
+        );
 
         let all_events = events | KeyboardMode::REPORT_ALL_KEYS_AS_ESC;
         assert_eq!(
@@ -1197,6 +1216,52 @@ mod tests {
         assert_eq!(
             action_seq("ab", KeyAction::Press, all_events).unwrap(),
             "\u{1b}[97u\u{1b}[97;1:3u\u{1b}[98u\u{1b}[98;1:3u"
+        );
+    }
+
+    /// A key release carries no text, so under `REPORT_EVENT_TYPES` it is
+    /// reported as an escape code even when the press of the same key was
+    /// plain text. The spec exempts Enter, Tab and Backspace from this so
+    /// that `reset` stays typable at a shell prompt after a program leaves
+    /// the mode set; report-all lifts the exemption.
+    #[test]
+    fn releases_are_reported_under_event_types_except_the_safety_keys() {
+        let events = KeyboardMode::REPORT_EVENT_TYPES;
+        for (token, release) in [
+            ("a", "\u{1b}[97;1:3u"),
+            ("Space", "\u{1b}[32;1:3u"),
+            ("Escape", "\u{1b}[27;1:3u"),
+            ("Enter", ""),
+            ("Tab", ""),
+            ("Backspace", ""),
+        ] {
+            assert_eq!(
+                action_seq(token, KeyAction::Up, events).unwrap(),
+                release,
+                "{token} release"
+            );
+        }
+
+        let all = events | KeyboardMode::REPORT_ALL_KEYS_AS_ESC;
+        for token in ["Enter", "Tab", "Backspace"] {
+            assert_ne!(
+                action_seq(token, KeyAction::Up, all).unwrap(),
+                "",
+                "{token} release once report-all lifts the exemption"
+            );
+        }
+    }
+
+    /// A repeat is not a release: holding a key down means more text, so a
+    /// text-producing key repeats as its text rather than as an escape code.
+    #[test]
+    fn repeats_of_text_keys_stay_text_under_event_types() {
+        let events = KeyboardMode::REPORT_EVENT_TYPES;
+        assert_eq!(action_seq("a", KeyAction::Repeat, events).unwrap(), "a");
+        assert_eq!(
+            action_seq("Ctrl+a", KeyAction::Repeat, events).unwrap(),
+            "\u{1b}[97;5:2u",
+            "a key with no text of its own still reports the repeat"
         );
     }
 

--- a/crates/tui-test/src/terminal/alacritty.rs
+++ b/crates/tui-test/src/terminal/alacritty.rs
@@ -404,6 +404,10 @@ impl Emulator for AlacrittyEmu {
             .collect()
     }
 
+    fn cursor_key_application(&self) -> bool {
+        self.term.mode().contains(TermMode::APP_CURSOR)
+    }
+
     fn clipboard(&self, clipboard: ClipboardType) -> anyhow::Result<String> {
         Ok(self
             .clipboard

--- a/crates/tui-test/src/terminal/conformance.rs
+++ b/crates/tui-test/src/terminal/conformance.rs
@@ -40,6 +40,14 @@ pub enum Divergence {
     /// able to tell that two runs of cells belong to the same link when they
     /// are not adjacent.
     HyperlinkHasNoId,
+    /// The backend does not implement the Kitty keyboard protocol at all, so
+    /// it can never report a mode the child pushed.
+    ///
+    /// Unlike the other variants this one is visible to a user: key input
+    /// falls back to legacy encodings even for a child that asked for `CSI u`.
+    /// It belongs here rather than in a profile default because it is the
+    /// emulator's own limit, not a setting.
+    NoKittyKeyboard,
 }
 
 /// Generates the conformance tests for one backend. `$make` builds a boxed
@@ -416,6 +424,54 @@ macro_rules! emulator_conformance_tests {
                 "SGR 0 does not clear the link"
             );
             assert_eq!(rows[0][2].uri(), None, "only OSC 8 closes the link");
+        }
+
+        /// A child pushes Kitty keyboard modes with `CSI > Ps u` and pops them
+        /// with `CSI < u`. Every backend that implements the protocol has to
+        /// report the same flags, because `key press` encodes from them: a
+        /// backend that under-reports silently sends legacy keys to a child
+        /// that asked for `CSI u`.
+        #[test]
+        fn conformance_kitty_keyboard_modes_are_pushed_and_popped() {
+            if CONFORMANCE_DIVERGENCES
+                .contains(&$crate::terminal::conformance::Divergence::NoKittyKeyboard)
+            {
+                return;
+            }
+            use $crate::terminal::emu::KeyboardMode as K;
+            let mut e = conformance_emu(10, 2, 100);
+            assert_eq!(e.keyboard_mode(), K::empty(), "nothing is on to start");
+
+            e.process(b"\x1b[>3u");
+            assert_eq!(
+                e.keyboard_mode(),
+                K::DISAMBIGUATE_ESC_CODES | K::REPORT_EVENT_TYPES,
+                "1 and 2 are the two bits of 3"
+            );
+
+            e.process(b"\x1b[>31u");
+            assert_eq!(
+                e.keyboard_mode(),
+                K::DISAMBIGUATE_ESC_CODES
+                    | K::REPORT_EVENT_TYPES
+                    | K::REPORT_ALTERNATE_KEYS
+                    | K::REPORT_ALL_KEYS_AS_ESC
+                    | K::REPORT_ASSOCIATED_TEXT,
+                "every flag maps to its own bit"
+            );
+
+            e.process(b"\x1b[<u");
+            assert_eq!(
+                e.keyboard_mode(),
+                K::DISAMBIGUATE_ESC_CODES | K::REPORT_EVENT_TYPES,
+                "popping restores what was underneath"
+            );
+            e.process(b"\x1b[<u");
+            assert_eq!(
+                e.keyboard_mode(),
+                K::empty(),
+                "popping the last leaves none"
+            );
         }
 
         /// Resetting the underline color must not be confusable with setting

--- a/crates/tui-test/src/terminal/emu.rs
+++ b/crates/tui-test/src/terminal/emu.rs
@@ -264,6 +264,36 @@ pub trait Emulator: Send {
         false
     }
 
+    /// Encode one key event with the backend's own key encoder.
+    ///
+    /// `None` means the backend has no encoder, or has one that cannot express
+    /// this event, and the caller falls back to [`crate::input::keys`]. Only
+    /// ghostty ships an encoder: alacritty and rio keep theirs in their GUI
+    /// crates rather than their VT libraries, and the xterm.js headless bundle
+    /// omits `evaluateKeyboardEvent` entirely.
+    ///
+    /// Preferring the backend matters because encoding depends on more terminal
+    /// state than the shared encoder models, and a backend's own encoder reads
+    /// that state directly. Ghostty's, for one, applies keypad application
+    /// mode, `modifyOtherKeys`, and the alt-escape prefix, none of which are
+    /// visible through this trait.
+    ///
+    /// An empty `Vec` is a real answer, not an absence: some events encode to
+    /// nothing at all, such as a bare modifier press.
+    fn encode_key(&self, _press: &crate::input::keys::KeyPress) -> Option<Vec<u8>> {
+        None
+    }
+
+    /// Whether the cursor keys are in application mode (`DECCKM`, `CSI ?1h`).
+    ///
+    /// A child in this mode expects `SS3 A` from the up arrow rather than
+    /// `CSI A`, and readline, vim, and less all turn it on. It is part of this
+    /// trait for the same reason [`Emulator::keyboard_mode`] is: key encoding
+    /// is shared, so anything it has to branch on has to be readable here.
+    fn cursor_key_application(&self) -> bool {
+        false
+    }
+
     fn resize(&mut self, cols: u16, rows: u16);
 
     /// Current grid size as `(cols, rows)`.

--- a/crates/tui-test/src/terminal/ghostty/core.rs
+++ b/crates/tui-test/src/terminal/ghostty/core.rs
@@ -320,15 +320,33 @@ impl GhosttyCore {
             event.set_consumed_mods(GhosttyMods::SHIFT);
         }
 
-        // A key that produces text has to say so. Ghostty encodes nothing at
-        // all for a text-bearing key with no `utf8` set, and needs it for the
-        // associated-text and alternate-key parts of the Kitty protocol.
-        // `unshifted_codepoint` is what the key sits on, which is exactly what
-        // `KeyPress::key` already holds for a character.
-        let mut chars = press.key.chars();
-        if let (Some(ch), None) = (chars.next(), chars.next()) {
+        // The codepoint the key sits on. Ghostty builds the Kitty `CSI <code> u`
+        // form from it, so a key without one is encoded as its text alone and
+        // silently loses its modifiers: `Ctrl+Space` came out as a plain space.
+        //
+        // For a character the key *is* the codepoint. For a named key it is
+        // not — `space` is a word — so the text it produces stands in, which
+        // is how `space` gets U+0020. Named keys that produce no text, such as
+        // Enter and Tab, need nothing here: ghostty knows their codepoints
+        // from the `Key` itself.
+        //
+        // Taken from the key before the text so that `Shift+a` reports `a`
+        // rather than the `A` it produced.
+        let single = |s: &str| {
+            let mut chars = s.chars();
+            match (chars.next(), chars.next()) {
+                (Some(ch), None) => Some(ch),
+                _ => None,
+            }
+        };
+        if let Some(ch) = single(&press.key).or_else(|| press.text.as_deref().and_then(single)) {
             event.set_unshifted_codepoint(ch);
         }
+
+        // A key that produces text has to say so: ghostty encodes nothing at
+        // all for a text-bearing key with no `utf8` set, and needs it for the
+        // associated-text and alternate-key parts of the Kitty protocol. A
+        // release produces no text, only the key that was let go.
         if press.event != KeyEventKind::Release {
             if let Some(text) = press.text.as_deref() {
                 event.set_utf8(Some(text));

--- a/crates/tui-test/src/terminal/ghostty/core.rs
+++ b/crates/tui-test/src/terminal/ghostty/core.rs
@@ -345,12 +345,15 @@ impl GhosttyCore {
 
         // A key that produces text has to say so: ghostty encodes nothing at
         // all for a text-bearing key with no `utf8` set, and needs it for the
-        // associated-text and alternate-key parts of the Kitty protocol. A
-        // release produces no text, only the key that was let go.
-        if press.event != KeyEventKind::Release {
-            if let Some(text) = press.text.as_deref() {
-                event.set_utf8(Some(text));
-            }
+        // associated-text and alternate-key parts of the Kitty protocol.
+        //
+        // This is the text the key produces on the current layout rather than
+        // anything the event does with it, so it is set for a release too:
+        // ghostty derives the shifted alternate key from it, and withholding
+        // it made `Shift+a` release as `CSI 97;2:3u` instead of the
+        // `CSI 97:65;2:3u` its press had already reported.
+        if let Some(text) = press.text.as_deref() {
+            event.set_utf8(Some(text));
         }
 
         let mut encoder = Encoder::new().context("creating key encoder")?;

--- a/crates/tui-test/src/terminal/ghostty/core.rs
+++ b/crates/tui-test/src/terminal/ghostty/core.rs
@@ -9,6 +9,10 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
 use compact_str::CompactString;
 use ghostty_vt::error::Error as GhosttyError;
+use ghostty_vt::key::{
+    Action as GhosttyKeyAction, Encoder, Event as GhosttyKeyEvent, Key, KittyKeyFlags,
+    Mods as GhosttyMods, OptionAsAlt,
+};
 use ghostty_vt::render::{CellIterator, CursorVisualStyle, RowIterator};
 use ghostty_vt::screen::{Cell as GhosttyCell, CellContentTag, CellWide, GridRef};
 use ghostty_vt::style::{Palette, PaletteIndex, RgbColor, Style, StyleColor, Underline};
@@ -19,11 +23,12 @@ use ghostty_vt::terminal::{
 use ghostty_vt::{RenderState, Terminal};
 
 use crate::event::BellTracker;
+use crate::input::keys::{KeyEventKind, KeyPress, Mods};
 use crate::profile::{xterm_color, ColorSlot, Profile, Rgb};
 use crate::terminal::cell::{
     Attrs, Color, EmuCell, Hyperlink, LinkCache, UnderlineStyle, CONTINUATION,
 };
-use crate::terminal::emu::{Clipboard, ClipboardType, CursorShape};
+use crate::terminal::emu::{Clipboard, ClipboardType, CursorShape, KeyboardMode};
 
 fn to_ghostty_rgb(color: Rgb) -> RgbColor {
     RgbColor {
@@ -276,6 +281,114 @@ impl GhosttyCore {
         std::mem::take(&mut *self.pending.borrow_mut())
     }
 
+    /// Encode a key event with ghostty's own encoder.
+    ///
+    /// `set_options_from_terminal` is the point of routing here: it reads the
+    /// modes off the live terminal, so this applies keypad application mode,
+    /// `modifyOtherKeys`, and the alt-escape prefix, none of which the shared
+    /// encoder models.
+    ///
+    /// `Ok(None)` means ghostty cannot express this event and the caller
+    /// should fall back rather than send something wrong.
+    pub(super) fn encode_key(&self, press: &KeyPress) -> Result<Option<Vec<u8>>> {
+        // Ghostty's modifier bitmask has no Hyper or Meta, which the Kitty
+        // protocol does define. An event using one cannot be handed over
+        // without silently dropping the modifier.
+        if press.mods.has_kitty_only_modifier() {
+            return Ok(None);
+        }
+        let Some(key) = ghostty_key(&press.key) else {
+            return Ok(None);
+        };
+
+        let mut event = GhosttyKeyEvent::new().context("creating key event")?;
+        event
+            .set_key(key)
+            .set_action(match press.event {
+                KeyEventKind::Press => GhosttyKeyAction::Press,
+                KeyEventKind::Repeat => GhosttyKeyAction::Repeat,
+                KeyEventKind::Release => GhosttyKeyAction::Release,
+            })
+            .set_mods(ghostty_mods(press.mods));
+
+        // Shift that went into producing the text is *consumed*: it made `A`
+        // out of `a` and is not reported separately. Without this a plain
+        // `Shift+a` encodes as `CSI 97;2u` instead of the text `A`, and the
+        // Kitty spec is explicit that a text-producing key still sends its
+        // text when only disambiguation is on.
+        if press.mods.shift && press.text.as_deref().is_some_and(|text| text != press.key) {
+            event.set_consumed_mods(GhosttyMods::SHIFT);
+        }
+
+        // A key that produces text has to say so. Ghostty encodes nothing at
+        // all for a text-bearing key with no `utf8` set, and needs it for the
+        // associated-text and alternate-key parts of the Kitty protocol.
+        // `unshifted_codepoint` is what the key sits on, which is exactly what
+        // `KeyPress::key` already holds for a character.
+        let mut chars = press.key.chars();
+        if let (Some(ch), None) = (chars.next(), chars.next()) {
+            event.set_unshifted_codepoint(ch);
+        }
+        if press.event != KeyEventKind::Release {
+            if let Some(text) = press.text.as_deref() {
+                event.set_utf8(Some(text));
+            }
+        }
+
+        let mut encoder = Encoder::new().context("creating key encoder")?;
+        encoder.set_options_from_terminal(&self.terminal);
+        // `set_options_from_terminal` resets this to `False`, which is a
+        // macOS GUI question rather than a terminal one: with it off, Alt is
+        // Option and composes text instead of prefixing ESC. A headless
+        // session has no keyboard and no compose behavior, so Alt is Alt.
+        encoder.set_macos_option_as_alt(OptionAsAlt::True);
+        let mut out = Vec::with_capacity(16);
+        encoder
+            .encode_to_vec(&event, &mut out)
+            .context("encoding key event")?;
+        Ok(Some(out))
+    }
+
+    pub(super) fn cursor_key_application(&self) -> Result<bool> {
+        self.terminal
+            .mode(Mode::DECCKM)
+            .context("reading cursor key mode")
+    }
+
+    /// Kitty keyboard flags the child has pushed onto ghostty's mode stack.
+    pub(super) fn keyboard_mode(&self) -> Result<KeyboardMode> {
+        let flags = self
+            .terminal
+            .kitty_keyboard_flags()
+            .context("reading Kitty keyboard flags")?;
+        let mut mode = KeyboardMode::empty();
+        for (ghostty_flag, keyboard_flag) in [
+            (
+                KittyKeyFlags::DISAMBIGUATE,
+                KeyboardMode::DISAMBIGUATE_ESC_CODES,
+            ),
+            (
+                KittyKeyFlags::REPORT_EVENTS,
+                KeyboardMode::REPORT_EVENT_TYPES,
+            ),
+            (
+                KittyKeyFlags::REPORT_ALTERNATES,
+                KeyboardMode::REPORT_ALTERNATE_KEYS,
+            ),
+            (
+                KittyKeyFlags::REPORT_ALL,
+                KeyboardMode::REPORT_ALL_KEYS_AS_ESC,
+            ),
+            (
+                KittyKeyFlags::REPORT_ASSOCIATED,
+                KeyboardMode::REPORT_ASSOCIATED_TEXT,
+            ),
+        ] {
+            mode.set(keyboard_flag, flags.contains(ghostty_flag));
+        }
+        Ok(mode)
+    }
+
     pub(super) fn set_clipboard(&mut self, clipboard: ClipboardType, text: String) {
         self.clipboard.set(clipboard, text);
     }
@@ -477,6 +590,100 @@ impl GhosttyCore {
             .or(configured)
             .ok_or_else(|| anyhow!("Ghostty returned no color for {slot:?}"))
     }
+}
+
+fn ghostty_mods(mods: Mods) -> GhosttyMods {
+    let mut out = GhosttyMods::empty();
+    out.set(GhosttyMods::CTRL, mods.ctrl);
+    out.set(GhosttyMods::ALT, mods.alt);
+    out.set(GhosttyMods::SHIFT, mods.shift);
+    out.set(GhosttyMods::SUPER, mods.super_key);
+    out
+}
+
+/// The ghostty key for one of tui-test's lowercased key names.
+///
+/// Ghostty's `Key` is a physical key code in the W3C spelling, so this is a
+/// translation of naming rather than of meaning. `None` means ghostty has no
+/// key for it and the caller falls back to the shared encoder.
+fn ghostty_key(name: &str) -> Option<Key> {
+    Some(match name {
+        "up" => Key::ArrowUp,
+        "down" => Key::ArrowDown,
+        "left" => Key::ArrowLeft,
+        "right" => Key::ArrowRight,
+        "home" => Key::Home,
+        "end" => Key::End,
+        "pageup" => Key::PageUp,
+        "pagedown" => Key::PageDown,
+        "insert" => Key::Insert,
+        "delete" => Key::Delete,
+        "backspace" => Key::Backspace,
+        "tab" => Key::Tab,
+        "enter" | "return" => Key::Enter,
+        "space" => Key::Space,
+        "escape" | "esc" => Key::Escape,
+        "f1" => Key::F1,
+        "f2" => Key::F2,
+        "f3" => Key::F3,
+        "f4" => Key::F4,
+        "f5" => Key::F5,
+        "f6" => Key::F6,
+        "f7" => Key::F7,
+        "f8" => Key::F8,
+        "f9" => Key::F9,
+        "f10" => Key::F10,
+        "f11" => Key::F11,
+        "f12" => Key::F12,
+        "a" => Key::A,
+        "b" => Key::B,
+        "c" => Key::C,
+        "d" => Key::D,
+        "e" => Key::E,
+        "f" => Key::F,
+        "g" => Key::G,
+        "h" => Key::H,
+        "i" => Key::I,
+        "j" => Key::J,
+        "k" => Key::K,
+        "l" => Key::L,
+        "m" => Key::M,
+        "n" => Key::N,
+        "o" => Key::O,
+        "p" => Key::P,
+        "q" => Key::Q,
+        "r" => Key::R,
+        "s" => Key::S,
+        "t" => Key::T,
+        "u" => Key::U,
+        "v" => Key::V,
+        "w" => Key::W,
+        "x" => Key::X,
+        "y" => Key::Y,
+        "z" => Key::Z,
+        "0" => Key::Digit0,
+        "1" => Key::Digit1,
+        "2" => Key::Digit2,
+        "3" => Key::Digit3,
+        "4" => Key::Digit4,
+        "5" => Key::Digit5,
+        "6" => Key::Digit6,
+        "7" => Key::Digit7,
+        "8" => Key::Digit8,
+        "9" => Key::Digit9,
+        "`" => Key::Backquote,
+        "\\" => Key::Backslash,
+        "[" => Key::BracketLeft,
+        "]" => Key::BracketRight,
+        "," => Key::Comma,
+        "=" => Key::Equal,
+        "-" => Key::Minus,
+        "." => Key::Period,
+        "'" => Key::Quote,
+        ";" => Key::Semicolon,
+        "/" => Key::Slash,
+        _ => return None,
+    })
 }
 
 #[cfg(test)]

--- a/crates/tui-test/src/terminal/ghostty/core.rs
+++ b/crates/tui-test/src/terminal/ghostty/core.rs
@@ -291,10 +291,18 @@ impl GhosttyCore {
     /// `Ok(None)` means ghostty cannot express this event and the caller
     /// should fall back rather than send something wrong.
     pub(super) fn encode_key(&self, press: &KeyPress) -> Result<Option<Vec<u8>>> {
-        // Ghostty's modifier bitmask has no Hyper or Meta, which the Kitty
-        // protocol does define. An event using one cannot be handed over
-        // without silently dropping the modifier.
-        if press.mods.has_kitty_only_modifier() {
+        // Ghostty's modifier bitmask has Ctrl, Alt, Shift and Super, but no
+        // Hyper or Meta, which the Kitty protocol does define. An event using
+        // one of those can never be handed over without dropping it.
+        if press.mods.hyper || press.mods.meta {
+            return Ok(None);
+        }
+        // Super is representable and encodes correctly in any Kitty mode, but
+        // the legacy encoding has no form that carries it: with no flags set
+        // ghostty answers `super+a` with nothing at all and `ctrl+super+a`
+        // with `CSI 97;5u`, which is `ctrl+a` with the Super quietly gone.
+        // Declining hands those to the shared encoder, which does carry it.
+        if press.mods.super_key && self.keyboard_mode()?.is_empty() {
             return Ok(None);
         }
         let Some(key) = ghostty_key(&press.key) else {

--- a/crates/tui-test/src/terminal/ghostty/mod.rs
+++ b/crates/tui-test/src/terminal/ghostty/mod.rs
@@ -439,6 +439,31 @@ mod tests {
         }
     }
 
+    /// The text a key produces belongs to the key and the layout, not to the
+    /// press, so it is handed over for a release too: ghostty derives the
+    /// shifted alternate key from it, and withholding it made `Shift+a`
+    /// release as `CSI 97;2:3u` after its press had reported `CSI 97:65;2u`.
+    #[test]
+    fn a_release_still_reports_the_shifted_alternate_key() {
+        let mut emu = GhosttyEmu::new(10, 2, &Profile::default()).unwrap();
+        emu.process(b"\x1b[>15u");
+        for (token, down, up) in [
+            ("Shift+a", &b"\x1b[97:65;2u"[..], &b"\x1b[97:65;2:3u"[..]),
+            ("Shift+1", &b"\x1b[49:33;2u"[..], &b"\x1b[49:33;2:3u"[..]),
+        ] {
+            for (action, want) in [(KeyAction::Down, down), (KeyAction::Up, up)] {
+                let presses =
+                    crate::input::keys::token_to_presses(token, action).expect("valid token");
+                let got: Option<Vec<u8>> = presses
+                    .iter()
+                    .map(|p| emu.encode_key(p))
+                    .collect::<Option<Vec<_>>>()
+                    .map(|parts| parts.concat());
+                assert_eq!(got.as_deref(), Some(want), "{token} {action:?}");
+            }
+        }
+    }
+
     /// Legacy mode has no codepoint form, so the same keys stay bytes.
     #[test]
     fn a_named_key_keeps_its_legacy_bytes() {

--- a/crates/tui-test/src/terminal/ghostty/mod.rs
+++ b/crates/tui-test/src/terminal/ghostty/mod.rs
@@ -13,9 +13,12 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
 
 use crate::event::BellTracker;
+use crate::input::keys::KeyPress;
 use crate::profile::{ColorSlot, Profile, Rgb};
 use crate::terminal::cell::EmuCell;
-use crate::terminal::emu::{ClipboardType, ClipboardValidator, CursorShape, Emulator};
+use crate::terminal::emu::{
+    ClipboardType, ClipboardValidator, CursorShape, Emulator, KeyboardMode,
+};
 
 use self::core::GhosttyCore;
 
@@ -261,6 +264,23 @@ impl Emulator for GhosttyEmu {
         self.call("draining replies", GhosttyCore::take_pending_writes)
     }
 
+    fn encode_key(&self, press: &KeyPress) -> Option<Vec<u8>> {
+        // The worker owns the terminal, so the event has to be moved across
+        // the channel rather than borrowed.
+        let press = press.clone();
+        self.call_result("encoding key", move |core| core.encode_key(&press))
+    }
+
+    fn cursor_key_application(&self) -> bool {
+        self.call_result("reading cursor key mode", |core| {
+            core.cursor_key_application()
+        })
+    }
+
+    fn keyboard_mode(&self) -> KeyboardMode {
+        self.call_result("reading keyboard mode", |core| core.keyboard_mode())
+    }
+
     fn clipboard(&self, clipboard: ClipboardType) -> anyhow::Result<String> {
         Ok(self.call("reading clipboard", move |core| core.clipboard(clipboard)))
     }
@@ -334,6 +354,69 @@ mod tests {
             crate::terminal::conformance::Divergence::HyperlinkHasNoId,
         ]
     );
+
+    fn press(key: &str) -> KeyPress {
+        crate::input::keys::token_to_presses(key, crate::api::KeyAction::Down)
+            .expect("valid token")
+            .remove(0)
+    }
+
+    /// The whole point of routing: ghostty's encoder reads the modes off the
+    /// live terminal, so `DECCKM` reaches key encoding without this backend
+    /// having to report the mode separately.
+    #[test]
+    fn the_encoder_follows_the_terminals_cursor_key_mode() {
+        let mut emu = GhosttyEmu::new(10, 2, &Profile::default()).unwrap();
+        assert_eq!(
+            emu.encode_key(&press("up")).as_deref(),
+            Some(&b"\x1b[A"[..])
+        );
+
+        emu.process(b"\x1b[?1h");
+        assert_eq!(
+            emu.encode_key(&press("up")).as_deref(),
+            Some(&b"\x1bOA"[..])
+        );
+
+        emu.process(b"\x1b[?1l");
+        assert_eq!(
+            emu.encode_key(&press("up")).as_deref(),
+            Some(&b"\x1b[A"[..])
+        );
+    }
+
+    /// Kitty flags reach the encoder from the same terminal state.
+    #[test]
+    fn the_encoder_follows_the_negotiated_kitty_flags() {
+        let mut emu = GhosttyEmu::new(10, 2, &Profile::default()).unwrap();
+        assert_eq!(emu.encode_key(&press("a")).as_deref(), Some(&b"a"[..]));
+
+        emu.process(b"\x1b[>1u");
+        assert_eq!(
+            emu.encode_key(&press("Escape")).as_deref(),
+            Some(&b"\x1b[27u"[..]),
+            "disambiguation is what mode 1 asks for"
+        );
+    }
+
+    /// A modifier ghostty's bitmask cannot represent has to decline rather
+    /// than encode without it, so the caller falls back instead of silently
+    /// sending a key with the modifier dropped.
+    #[test]
+    fn kitty_only_modifiers_decline_rather_than_lose_the_modifier() {
+        let emu = GhosttyEmu::new(10, 2, &Profile::default()).unwrap();
+        for modifier in ["hyper", "meta"] {
+            let event = press(&format!("{modifier}+a"));
+            assert_eq!(emu.encode_key(&event), None, "{modifier} is not encodable");
+        }
+    }
+
+    /// A key ghostty has no code for declines too.
+    #[test]
+    fn an_unmapped_key_declines() {
+        let emu = GhosttyEmu::new(10, 2, &Profile::default()).unwrap();
+        assert_eq!(emu.encode_key(&press("\u{4f60}")), None);
+    }
 
     #[test]
     fn bells_are_counted_without_counting_osc_terminators() {

--- a/crates/tui-test/src/terminal/ghostty/mod.rs
+++ b/crates/tui-test/src/terminal/ghostty/mod.rs
@@ -464,6 +464,71 @@ mod tests {
         }
     }
 
+    /// Super is a modifier ghostty can carry, but only in a Kitty mode.
+    ///
+    /// The bitmask has Ctrl, Alt, Shift and Super, so a Kitty encoding reports
+    /// it. The legacy encoding has no form for it and drops it silently:
+    /// `super+a` came back empty and `ctrl+super+a` as `CSI 97;5u`, which is
+    /// `ctrl+a` with the Super gone. Declining there sends it to the shared
+    /// encoder, which carries it.
+    #[test]
+    fn super_encodes_in_a_kitty_mode_and_declines_in_legacy() {
+        let legacy = GhosttyEmu::new(10, 2, &Profile::default()).unwrap();
+        for token in ["super+a", "ctrl+super+a"] {
+            assert_eq!(
+                legacy.encode_key(&press(token)),
+                None,
+                "{token} has no legacy form that keeps Super"
+            );
+        }
+
+        let mut emu = GhosttyEmu::new(10, 2, &Profile::default()).unwrap();
+        emu.process(b"\x1b[>1u");
+        for (token, want) in [
+            ("super+a", &b"\x1b[97;9u"[..]),
+            ("ctrl+super+a", &b"\x1b[97;13u"[..]),
+        ] {
+            assert_eq!(
+                emu.encode_key(&press(token)).as_deref(),
+                Some(want),
+                "{token} reports Super"
+            );
+        }
+    }
+
+    /// A key that produces text sends the text until keys are reported as
+    /// escape codes, however it is modified.
+    ///
+    /// `Shift+Space` looks like it should be `CSI 32;2u` everywhere, but kitty
+    /// returns text for any press that carries some unless the report-all-keys
+    /// flag is set (`send_text_standalone = !report_text` in `key_encoding.c`),
+    /// so a space is right until then. The release has no text and is an
+    /// escape code as soon as event types are reported.
+    #[test]
+    fn shift_space_sends_text_until_keys_are_escape_codes() {
+        for (flags, down, up) in [
+            (0u8, &b" "[..], &b""[..]),
+            (1, b" ", b""),
+            (3, b" ", b"\x1b[32;2:3u"),
+            (15, b"\x1b[32;2u", b"\x1b[32;2:3u"),
+        ] {
+            let mut emu = GhosttyEmu::new(10, 2, &Profile::default()).unwrap();
+            if flags > 0 {
+                emu.process(format!("\x1b[>{flags}u").as_bytes());
+            }
+            for (action, want) in [(KeyAction::Down, down), (KeyAction::Up, up)] {
+                let presses = crate::input::keys::token_to_presses("shift+space", action)
+                    .expect("valid token");
+                let got: Option<Vec<u8>> = presses
+                    .iter()
+                    .map(|p| emu.encode_key(p))
+                    .collect::<Option<Vec<_>>>()
+                    .map(|parts| parts.concat());
+                assert_eq!(got.as_deref(), Some(want), "flags {flags} {action:?}");
+            }
+        }
+    }
+
     /// Legacy mode has no codepoint form, so the same keys stay bytes.
     #[test]
     fn a_named_key_keeps_its_legacy_bytes() {

--- a/crates/tui-test/src/terminal/ghostty/mod.rs
+++ b/crates/tui-test/src/terminal/ghostty/mod.rs
@@ -341,6 +341,7 @@ impl Emulator for GhosttyEmu {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::KeyAction;
 
     crate::emulator_conformance_tests!(
         |cols, rows, profile| {
@@ -356,7 +357,7 @@ mod tests {
     );
 
     fn press(key: &str) -> KeyPress {
-        crate::input::keys::token_to_presses(key, crate::api::KeyAction::Down)
+        crate::input::keys::token_to_presses(key, KeyAction::Down)
             .expect("valid token")
             .remove(0)
     }
@@ -408,6 +409,50 @@ mod tests {
         for modifier in ["hyper", "meta"] {
             let event = press(&format!("{modifier}+a"));
             assert_eq!(emu.encode_key(&event), None, "{modifier} is not encodable");
+        }
+    }
+
+    /// A named key still sits on a codepoint. Without one ghostty encodes the
+    /// key as its bare text and the modifiers vanish, so `Ctrl+Space` arrives
+    /// as a plain space instead of `CSI 32;5u` and a release sends nothing at
+    /// all. Legacy mode never showed it because there the text *is* the answer.
+    #[test]
+    fn a_named_key_carries_its_codepoint_into_kitty_mode() {
+        let mut emu = GhosttyEmu::new(10, 2, &Profile::default()).unwrap();
+        emu.process(b"\x1b[>15u");
+
+        for (token, down, up) in [
+            ("space", &b"\x1b[32u"[..], &b"\x1b[32;1:3u"[..]),
+            ("ctrl+space", &b"\x1b[32;5u"[..], &b"\x1b[32;5:3u"[..]),
+            ("alt+space", &b"\x1b[32;3u"[..], &b"\x1b[32;3:3u"[..]),
+        ] {
+            for (action, want) in [(KeyAction::Down, down), (KeyAction::Up, up)] {
+                let presses =
+                    crate::input::keys::token_to_presses(token, action).expect("valid token");
+                let got: Option<Vec<u8>> = presses
+                    .iter()
+                    .map(|p| emu.encode_key(p))
+                    .collect::<Option<Vec<_>>>()
+                    .map(|parts| parts.concat());
+                assert_eq!(got.as_deref(), Some(want), "{token} {action:?}");
+            }
+        }
+    }
+
+    /// Legacy mode has no codepoint form, so the same keys stay bytes.
+    #[test]
+    fn a_named_key_keeps_its_legacy_bytes() {
+        let emu = GhosttyEmu::new(10, 2, &Profile::default()).unwrap();
+        for (token, want) in [
+            ("space", &b" "[..]),
+            ("ctrl+space", &b"\x00"[..]),
+            ("alt+space", &b"\x1b "[..]),
+        ] {
+            assert_eq!(
+                emu.encode_key(&press(token)).as_deref(),
+                Some(want),
+                "{token}"
+            );
         }
     }
 

--- a/crates/tui-test/src/terminal/rio.rs
+++ b/crates/tui-test/src/terminal/rio.rs
@@ -331,6 +331,10 @@ impl Emulator for RioEmu {
         std::mem::take(&mut *self.pending.lock().unwrap_or_else(PoisonError::into_inner))
     }
 
+    fn cursor_key_application(&self) -> bool {
+        self.term.mode().contains(Mode::APP_CURSOR)
+    }
+
     fn clipboard(&self, clipboard: ClipboardType) -> anyhow::Result<String> {
         Ok(self
             .clipboard

--- a/crates/tui-test/src/terminal/xtermjs.rs
+++ b/crates/tui-test/src/terminal/xtermjs.rs
@@ -481,6 +481,10 @@ impl Emulator for XtermJsEmu {
         self.call_or("cursorVisible", true)
     }
 
+    fn cursor_key_application(&self) -> bool {
+        self.call_or("cursorKeyApplication", 0) != 0
+    }
+
     fn cursor_shape(&self) -> CursorShape {
         match self.call::<String>("cursorShape").as_str() {
             "underline" => CursorShape::Underline,
@@ -615,6 +619,10 @@ mod tests {
             crate::terminal::conformance::Divergence::UnderlineColorNeedsAStyle,
             // Clipboard access is unavailable.
             crate::terminal::conformance::Divergence::ClipboardUnsupported,
+            // xterm.js has no Kitty keyboard protocol implementation at all:
+            // the bundle contains no handler for `CSI > u`, `CSI = u`, or
+            // `CSI < u`, so the modes a child pushes are parsed and dropped.
+            crate::terminal::conformance::Divergence::NoKittyKeyboard,
         ]
     );
 }

--- a/references/cli.md
+++ b/references/cli.md
@@ -54,6 +54,7 @@ Style options: `--fg`, `--bg`, `--bold`, `--dim`, `--italic`, `--underline-style
 | `mouse down\|up X Y [options]` | Press or release a button. |
 | `mouse drag X1 Y1 X2 Y2 [options]` | Drag. |
 | `mouse scroll up\|down [--amount N]` | Scroll. |
+
 | `resize COLS ROWS` | Resize. |
 | `signal NAME` | Send a signal. |
 


### PR DESCRIPTION
Routes key encoding to a backend's own encoder where one exists, fixes a bug that finding out about surfaced, and implements a `keyboard_mode` that ghostty never had.

## Three problems

**`keys.rs` modelled no DECCKM at all.** `CSI ?1h` moves the cursor keys from `CSI A` onto `SS3 A`, and readline, vim and less all set it — so `key press Up` has been sending `CSI A` to children that asked for `SS3 A`.

**ghostty never reported any Kitty flags.** `Emulator::keyboard_mode` has a default returning `KeyboardMode::empty()`, and `GhosttyEmu` never overrode it, so every key reaching a ghostty session was legacy-encoded no matter what the child had negotiated. `libghostty-vt` exposed the state as `Terminal::kitty_keyboard_flags()` the whole time; it was simply never called.

**Encoding ignored terminal state the backends already track.** Keypad application mode, `modifyOtherKeys`, the alt-escape prefix — none of it was modelled.

## The routing

`Emulator::encode_key(&KeyPress) -> Option<Vec<u8>>`, defaulting to `None`. A backend with an encoder uses it; `None` falls back to the shared one.

| backend | own encoder? | why |
| --- | --- | --- |
| ghostty | **yes** | `ghostty_vt::key::Encoder` |
| alacritty | no | encoding lives in the `alacritty` GUI crate, not `alacritty_terminal` |
| rio | no | same split; `rio-vt` has only hex and graphics encoders |
| xtermjs | no | `evaluateKeyboardEvent` is in `browser/`, absent from the headless bundle |

Ghostty's `set_options_from_terminal` reads the live terminal, so routing to it applies the modes the shared encoder does not model.

**Declining is a feature.** Ghostty's modifier bitmask has no Hyper or Meta, which the Kitty protocol does define. Rather than encode without them, `encode_key` returns `None` and the event falls back, so a modifier is never silently dropped. Fallback is all-or-nothing per token, since a token half-encoded by each would interleave two encodings of one keypress.

## DECCKM

Reaches exactly the keys `CSI ... A`-`D`, `H` and `F` spell, and only unmodified presses — which is already what `ss3_unmodified` means for F1-F4, so it reuses that rather than adding a second rule that could drift. A modified cursor key stays `CSI` (`SS3` has nowhere to put the parameter), and the Kitty protocol outranks the mode entirely.

Ghostty encodes its own DECCKM; the shared encoder's covers the other three. Without both halves this PR would have made ghostty correct and left the others wrong — a divergence introduced by a fix.

## Four bugs found by #183

The differential test in #183 was written against this branch and immediately found four bugs in it:

| symptom | cause |
| --- | --- |
| `key press A` sent `a` | tokens were lowercased wholesale — right for a named key, wrong for a character |
| `key press Space` sent nothing | ghostty encodes a text-bearing key with no `utf8` as empty, and only single-character tokens set it |
| `key press Alt+a` sent `a` | `set_options_from_terminal` resets `macos_option_as_alt` to `False`, so Alt composed instead of prefixing ESC |
| `Shift+a` sent `CSI 97;2u` instead of `A` | `consumed_mods` was never set, so ghostty reported a Shift already spent producing the text |

`KeyPress` now carries the *unshifted* key plus the `text` it produces, so `!` arrives as `"1"` with shift and text `"!"`. Text is carried rather than derived because deriving it needs a keyboard layout.

## Not in this PR any more

The `kitty_keyboard` profile toggle that #180 proposed. A terminal either implements the protocol or it does not, and simulating the second case by gating the VT layer tests tui-test's own plumbing rather than a real terminal — that belongs in the keyboard harness, which is what this PR builds. #180 is closed; what it carried that was worth keeping lives here: ghostty's `keyboard_mode`, the push/pop conformance case, and the `NoKittyKeyboard` divergence for xterm.js (tracked for the 6.1.0 bundle in #179).

## Shape

`InputModes` groups the state encoding branches on, and public entry points take `impl Into<InputModes>` with `From<KeyboardMode>`, so existing callers and all 32 existing test call sites compile untouched. `Emulator::cursor_key_application` is implemented by all four backends.

## Tests

Five DECCKM cases, four routing cases against a real ghostty terminal, and a conformance case pinning Kitty push/pop for every backend that claims the protocol — the case that would have caught the ghostty gap.

Based on `main`; #183 stacks on this.
