### PR TITLE
feat(assert): match a cell by its OSC 8 link

### DIFF
--- a/bindings/js/native/index.d.ts
+++ b/bindings/js/native/index.d.ts
@@ -165,6 +165,7 @@ export interface LocatorStyle {
   hidden?: boolean
   strikethrough?: boolean
   blink?: boolean
+  link?: string
 }
 
 export interface MouseClickOptions {

--- a/bindings/js/native/lib.rs
+++ b/bindings/js/native/lib.rs
@@ -461,6 +461,7 @@ pub struct LocatorStyle {
     pub hidden: Option<bool>,
     pub strikethrough: Option<bool>,
     pub blink: Option<bool>,
+    pub link: Option<String>,
 }
 
 #[napi(object)]
@@ -647,6 +648,7 @@ fn core_style(style: LocatorStyle) -> CoreTextStyle {
         hidden: style.hidden,
         strikethrough: style.strikethrough,
         blink: style.blink,
+        link: style.link,
     }
 }
 

--- a/bindings/js/src/client.ts
+++ b/bindings/js/src/client.ts
@@ -79,6 +79,8 @@ export interface TextStyleExpectation {
   hidden?: boolean;
   strikethrough?: boolean;
   blink?: boolean;
+  /** Required OSC 8 link target. Pass `""` to require no link. */
+  link?: string;
 }
 
 export interface LocatorWaitOptions {
@@ -320,6 +322,7 @@ function textStyleValue(style: TextStyleExpectation): RuntimeLocatorStyle {
     hidden: style.hidden,
     strikethrough: style.strikethrough,
     blink: style.blink,
+    link: style.link,
   };
 }
 

--- a/bindings/python/native/src/lib.rs
+++ b/bindings/python/native/src/lib.rs
@@ -1457,6 +1457,7 @@ fn core_style(dict: &Bound<'_, PyDict>) -> Result<TextStyle, TuiTestError> {
         hidden: py_bool(dict, "hidden")?,
         strikethrough: py_bool(dict, "strikethrough")?,
         blink: py_bool(dict, "blink")?,
+        link: py_string(dict, "link")?,
     })
 }
 

--- a/bindings/python/src/tui_test/types.py
+++ b/bindings/python/src/tui_test/types.py
@@ -111,6 +111,7 @@ class TextStyle:
     hidden: Optional[bool] = None
     strikethrough: Optional[bool] = None
     blink: Optional[bool] = None
+    link: Optional[str] = None
 
 
 @dataclass

--- a/crates/tui-test-cli/src/cli.rs
+++ b/crates/tui-test-cli/src/cli.rs
@@ -857,6 +857,25 @@ mod tests {
         assert_eq!(query.style.underline_style.as_deref(), Some("curly"));
     }
 
+    /// `--link ""` has to survive parsing as an empty string rather than as
+    /// an absent option, because that is how a caller asks for a cell that
+    /// links nowhere.
+    #[test]
+    fn expect_text_accepts_a_link_target() {
+        for (argument, expected) in [("https://example.com", "https://example.com"), ("", "")] {
+            let cli =
+                Cli::try_parse_from(["tui-test", "expect", "text", "Docs", "--link", argument])
+                    .expect("parse link expectation");
+            let Some(Command::Expect {
+                what: ExpectCmd::Text { query, .. },
+            }) = cli.command
+            else {
+                panic!("expected Expect text");
+            };
+            assert_eq!(query.style.link.as_deref(), Some(expected));
+        }
+    }
+
     #[test]
     fn expect_exit_code_accepts_a_timeout() {
         let cli =
@@ -1213,6 +1232,9 @@ pub struct TextStyleArgs {
     pub strikethrough: Option<bool>,
     #[arg(long, num_args = 0..=1, default_missing_value = "true", require_equals = true)]
     pub blink: Option<bool>,
+    /// Required OSC 8 link target. Pass an empty string to require no link.
+    #[arg(long)]
+    pub link: Option<String>,
 }
 
 #[derive(Args)]

--- a/crates/tui-test-cli/src/main.rs
+++ b/crates/tui-test-cli/src/main.rs
@@ -513,6 +513,7 @@ fn map_style(args: TextStyleArgs) -> TextStyle {
         hidden: args.hidden,
         strikethrough: args.strikethrough,
         blink: args.blink,
+        link: args.link,
     }
 }
 

--- a/crates/tui-test/src/api.rs
+++ b/crates/tui-test/src/api.rs
@@ -384,6 +384,13 @@ pub struct TextStyle {
     pub hidden: Option<bool>,
     pub strikethrough: Option<bool>,
     pub blink: Option<bool>,
+    /// The OSC 8 URI a cell must link to.
+    ///
+    /// An empty string means "links nowhere", so a cell can be required to be
+    /// plain as well as required to be a link. That is why this is a
+    /// `String` rather than an `Option` used as the absence marker: the
+    /// `Option` already means "the caller did not ask".
+    pub link: Option<String>,
 }
 
 impl TextStyle {

--- a/crates/tui-test/src/api.rs
+++ b/crates/tui-test/src/api.rs
@@ -386,10 +386,23 @@ pub struct TextStyle {
     pub blink: Option<bool>,
     /// The OSC 8 URI a cell must link to.
     ///
+    /// A link is not an SGR attribute: `SGR 0` clears every other field here
+    /// and leaves the link running, and only `OSC 8` with an empty URI closes
+    /// it. It is matched alongside them because it is carried on a cell the
+    /// same way — set on the cursor, inherited by everything written while it
+    /// is open — so `{ bold: true, link: "..." }` is one query rather than two
+    /// that have to be intersected by hand.
+    ///
     /// An empty string means "links nowhere", so a cell can be required to be
     /// plain as well as required to be a link. That is why this is a
     /// `String` rather than an `Option` used as the absence marker: the
     /// `Option` already means "the caller did not ask".
+    ///
+    /// The `id=` parameter is deliberately not matchable. It exists to join
+    /// the runs of one logical link, which is worth asserting on in principle,
+    /// but the ghostty backend cannot report it at all, so a query against it
+    /// would quietly mean different things on different backends. It stays
+    /// readable on a cell, where being backend-dependent is visible.
     pub link: Option<String>,
 }
 

--- a/crates/tui-test/src/engine.rs
+++ b/crates/tui-test/src/engine.rs
@@ -1968,6 +1968,11 @@ fn cell_matches_style(cell: &EmuCell, style: &TextStyle, colors: &dyn Emulator) 
     {
         return false;
     }
+    if let Some(expected) = style.link.as_deref() {
+        if expected != cell.uri().unwrap_or_default() {
+            return false;
+        }
+    }
     for (spec, actual, foreground) in [
         (&style.foreground, cell.fg, true),
         (&style.background, cell.bg, false),
@@ -2322,6 +2327,86 @@ mod tests {
             &cell,
             &TextStyle {
                 foreground: Some("#ff0000".into()),
+                ..TextStyle::default()
+            },
+            &emu,
+        ));
+    }
+
+    /// A link is matched by where it points, so a locator can find the cells
+    /// of one link and ignore an identical-looking one pointing elsewhere.
+    #[test]
+    fn style_locators_match_a_cell_by_its_link() {
+        let emu = AlacrittyEmu::new(10, 2, &Profile::default());
+        let linked = EmuCell {
+            ch: "x".into(),
+            hyperlink: Some(std::sync::Arc::new(crate::terminal::cell::Hyperlink {
+                id: None,
+                uri: "https://example.com".into(),
+            })),
+            ..EmuCell::blank()
+        };
+
+        let with_link = |uri: &str| TextStyle {
+            link: Some(uri.into()),
+            ..TextStyle::default()
+        };
+        assert!(cell_matches_style(
+            &linked,
+            &with_link("https://example.com"),
+            &emu
+        ));
+        assert!(!cell_matches_style(
+            &linked,
+            &with_link("https://other.example"),
+            &emu
+        ));
+    }
+
+    /// An empty link is a real requirement, not an absent one: it asks for a
+    /// cell that links nowhere, which is how a test asserts that a link was
+    /// closed rather than merely that some other link was not found.
+    #[test]
+    fn an_empty_link_requires_a_cell_that_links_nowhere() {
+        let emu = AlacrittyEmu::new(10, 2, &Profile::default());
+        let plain = EmuCell {
+            ch: "x".into(),
+            ..EmuCell::blank()
+        };
+        let linked = EmuCell {
+            hyperlink: Some(std::sync::Arc::new(crate::terminal::cell::Hyperlink {
+                id: None,
+                uri: "https://example.com".into(),
+            })),
+            ..plain.clone()
+        };
+        let unlinked = TextStyle {
+            link: Some(String::new()),
+            ..TextStyle::default()
+        };
+
+        assert!(cell_matches_style(&plain, &unlinked, &emu));
+        assert!(!cell_matches_style(&linked, &unlinked, &emu));
+    }
+
+    /// A style that says nothing about links keeps matching either kind, so
+    /// adding the field does not narrow every existing query.
+    #[test]
+    fn a_style_without_a_link_still_matches_a_linked_cell() {
+        let emu = AlacrittyEmu::new(10, 2, &Profile::default());
+        let linked = EmuCell {
+            ch: "x".into(),
+            attrs: Attrs::BOLD,
+            hyperlink: Some(std::sync::Arc::new(crate::terminal::cell::Hyperlink {
+                id: None,
+                uri: "https://example.com".into(),
+            })),
+            ..EmuCell::blank()
+        };
+        assert!(cell_matches_style(
+            &linked,
+            &TextStyle {
+                bold: Some(true),
                 ..TextStyle::default()
             },
             &emu,

--- a/crates/tui-test/src/terminal/locator.rs
+++ b/crates/tui-test/src/terminal/locator.rs
@@ -169,10 +169,18 @@ where
         !cell.cell.ch.is_empty() && !cell.cell.ch.chars().all(char::is_whitespace)
     };
     let has_visible = matched.cells.iter().any(&visible);
+    // A blank is skipped because a color it cannot show says nothing about the
+    // match: the foreground of a space is invisible, so requiring it would make
+    // `A B` fail for a reason no reader could see. A link is not like that. It
+    // is a region of the screen rather than an appearance, and a space inside
+    // one is part of the link, so a blank that links elsewhere is a real
+    // difference and has to be checked. Without this, `A B` whose space alone
+    // carries a URI would satisfy "links nowhere".
+    let linked = style.link.is_some();
     matched
         .cells
         .iter()
-        .filter(|cell| !has_visible || visible(cell))
+        .filter(|cell| linked || !has_visible || visible(cell))
         .all(|cell| style_matches(&cell.cell, style))
 }
 
@@ -947,5 +955,61 @@ mod tests {
         let found = locate_query_text(&rows, &query).unwrap();
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].value.start.column, 2);
+    }
+
+    /// A blank inside a match is skipped for a color, which it cannot show,
+    /// but not for a link, which it can carry. `A B` whose space alone links
+    /// somewhere is not a run that links nowhere.
+    #[test]
+    fn a_link_constraint_covers_the_blanks_inside_a_match() {
+        let link = |uri: &str| {
+            Some(std::sync::Arc::new(crate::terminal::cell::Hyperlink {
+                id: None,
+                uri: uri.into(),
+            }))
+        };
+        let mut rows = grid(&["A B"]);
+        rows[0][1].hyperlink = link("https://example.com");
+
+        let locate = |rows: &[Vec<EmuCell>], query: &LocatorQuery| {
+            locate_query(rows, query, &mut |cell, style: &TextStyle| {
+                style
+                    .link
+                    .as_deref()
+                    .is_none_or(|expected| expected == cell.uri().unwrap_or_default())
+            })
+        };
+        let with_link = |link: &str| LocatorQuery {
+            selector: LocatorSelector::Text(TextSelector::new("A B")),
+            occurrence: MatchOccurrence::Any,
+            within: None,
+            direction: LocatorDirection::Within,
+            style: TextStyle {
+                link: Some(link.to_string()),
+                ..TextStyle::default()
+            },
+        };
+
+        assert!(
+            locate(&rows, &with_link("")).unwrap().is_empty(),
+            "the linked space means the run does not link nowhere"
+        );
+        assert!(
+            locate(&rows, &with_link("https://example.com"))
+                .unwrap()
+                .is_empty(),
+            "and the unlinked letters mean it is not all one link either"
+        );
+
+        for cell in &mut rows[0] {
+            cell.hyperlink = link("https://example.com");
+        }
+        assert_eq!(
+            locate(&rows, &with_link("https://example.com"))
+                .unwrap()
+                .len(),
+            1,
+            "every cell linked, blanks included, matches"
+        );
     }
 }

--- a/crates/tui-test/src/terminal/locator.rs
+++ b/crates/tui-test/src/terminal/locator.rs
@@ -169,19 +169,45 @@ where
         !cell.cell.ch.is_empty() && !cell.cell.ch.chars().all(char::is_whitespace)
     };
     let has_visible = matched.cells.iter().any(&visible);
-    // A blank is skipped because a color it cannot show says nothing about the
-    // match: the foreground of a space is invisible, so requiring it would make
-    // `A B` fail for a reason no reader could see. A link is not like that. It
-    // is a region of the screen rather than an appearance, and a space inside
-    // one is part of the link, so a blank that links elsewhere is a real
-    // difference and has to be checked. Without this, `A B` whose space alone
-    // carries a URI would satisfy "links nowhere".
-    let linked = style.link.is_some();
-    matched
-        .cells
-        .iter()
-        .filter(|cell| linked || !has_visible || visible(cell))
-        .all(|cell| style_matches(&cell.cell, style))
+    // The two halves of a style are asked about differently, because a blank
+    // can carry one and not the other.
+    //
+    // An appearance skips blanks: the foreground of a space is invisible, so
+    // requiring it would fail `A B` for a reason no reader could see, and a
+    // program that bolds the letters but not the space between them has drawn
+    // exactly what the query describes.
+    //
+    // A link is not an appearance. It is a region of the screen, and a space
+    // inside one is part of the link, so it is checked on every cell —
+    // otherwise `A B` whose space alone carries a URI would satisfy "links
+    // nowhere".
+    //
+    // Splitting the two rather than picking one policy for the whole match is
+    // what keeps them composable: `A B` linked throughout but bold only on the
+    // letters matches `--bold --link` exactly as it matches either alone.
+    let link = style.link.as_ref().map(|link| TextStyle {
+        link: Some(link.clone()),
+        ..TextStyle::default()
+    });
+    let appearance = TextStyle {
+        link: None,
+        ..style.clone()
+    };
+    let appearance = (!appearance.is_empty()).then_some(appearance);
+
+    matched.cells.iter().all(|cell| {
+        if let Some(link) = &link {
+            if !style_matches(&cell.cell, link) {
+                return false;
+            }
+        }
+        match &appearance {
+            Some(appearance) if !has_visible || visible(cell) => {
+                style_matches(&cell.cell, appearance)
+            }
+            _ => true,
+        }
+    })
 }
 
 fn relative_regions(
@@ -1011,5 +1037,71 @@ mod tests {
             1,
             "every cell linked, blanks included, matches"
         );
+    }
+
+    /// Asking about a link and an appearance together means the same as asking
+    /// about each alone.
+    ///
+    /// `A B` linked throughout, with the letters bold and the space not — the
+    /// usual shape, since a program has no reason to bold a space. The blank
+    /// is skipped for bold, which it cannot show, and checked for the link,
+    /// which it carries. Treating one policy as the match's own would fail the
+    /// combination while passing both halves.
+    #[test]
+    fn a_link_and_an_appearance_compose() {
+        let mut rows = grid(&["A B"]);
+        for cell in &mut rows[0] {
+            cell.hyperlink = Some(std::sync::Arc::new(crate::terminal::cell::Hyperlink {
+                id: None,
+                uri: "https://example.com".into(),
+            }));
+        }
+        rows[0][0].attrs.insert(Attrs::BOLD);
+        rows[0][2].attrs.insert(Attrs::BOLD);
+
+        let locate = |style: TextStyle| {
+            locate_query(
+                &rows,
+                &LocatorQuery {
+                    selector: LocatorSelector::Text(TextSelector::new("A B")),
+                    occurrence: MatchOccurrence::Any,
+                    within: None,
+                    direction: LocatorDirection::Within,
+                    style,
+                },
+                &mut |cell, style: &TextStyle| {
+                    style
+                        .bold
+                        .is_none_or(|expected| expected == cell.has(Attrs::BOLD))
+                        && style
+                            .link
+                            .as_deref()
+                            .is_none_or(|expected| expected == cell.uri().unwrap_or_default())
+                },
+            )
+            .unwrap()
+            .len()
+        };
+        let bold = TextStyle {
+            bold: Some(true),
+            ..TextStyle::default()
+        };
+        let linked = TextStyle {
+            link: Some("https://example.com".to_string()),
+            ..TextStyle::default()
+        };
+        let both = TextStyle {
+            bold: Some(true),
+            link: Some("https://example.com".to_string()),
+            ..TextStyle::default()
+        };
+
+        assert_eq!(
+            locate(bold),
+            1,
+            "the space cannot show bold, so it is skipped"
+        );
+        assert_eq!(locate(linked), 1, "every cell carries the link");
+        assert_eq!(locate(both), 1, "so asking for both matches too");
     }
 }

--- a/references/cli.md
+++ b/references/cli.md
@@ -36,7 +36,9 @@ Common options:
 | `--match any\|unique\|first\|last` | Select matches. |
 | `--nth N` | Select a zero-based match. |
 
-Style options: `--fg`, `--bg`, `--bold`, `--dim`, `--italic`, `--underline-style`, `--underline-color`, `--inverse`, `--hidden`, `--strikethrough`, and `--blink`.
+Style options: `--fg`, `--bg`, `--bold`, `--dim`, `--italic`, `--underline-style`, `--underline-color`, `--inverse`, `--hidden`, `--strikethrough`, `--blink`, and `--link`.
+
+`--link` matches a cell's OSC 8 target: `--link https://example.com` requires that link, and `--link ""` requires a cell that links nowhere.
 
 `click text` also accepts `--button left|middle|right`, `--alt`, `--ctrl`, `--shift`, `--clicks`, and `--timeout`.
 

--- a/references/cli.md
+++ b/references/cli.md
@@ -38,7 +38,7 @@ Common options:
 
 Style options: `--fg`, `--bg`, `--bold`, `--dim`, `--italic`, `--underline-style`, `--underline-color`, `--inverse`, `--hidden`, `--strikethrough`, `--blink`, and `--link`.
 
-`--link` matches a cell's OSC 8 target: `--link https://example.com` requires that link, and `--link ""` requires a cell that links nowhere. It applies to every cell of the match, blanks included, because a space inside a link is part of the link.
+`--link` matches a cell's OSC 8 target: `--link https://example.com` requires that link, and `--link ""` requires a cell that links nowhere. It applies to every cell of the match, blanks included, because a space inside a link is part of the link. The appearance options skip blanks, which cannot show them, so `A B` linked throughout with only the letters bold matches `--bold --link ...` just as it matches either alone.
 
 `click text` also accepts `--button left|middle|right`, `--alt`, `--ctrl`, `--shift`, `--clicks`, and `--timeout`.
 

--- a/references/cli.md
+++ b/references/cli.md
@@ -38,7 +38,7 @@ Common options:
 
 Style options: `--fg`, `--bg`, `--bold`, `--dim`, `--italic`, `--underline-style`, `--underline-color`, `--inverse`, `--hidden`, `--strikethrough`, `--blink`, and `--link`.
 
-`--link` matches a cell's OSC 8 target: `--link https://example.com` requires that link, and `--link ""` requires a cell that links nowhere.
+`--link` matches a cell's OSC 8 target: `--link https://example.com` requires that link, and `--link ""` requires a cell that links nowhere. It applies to every cell of the match, blanks included, because a space inside a link is part of the link.
 
 `click text` also accepts `--button left|middle|right`, `--alt`, `--ctrl`, `--shift`, `--clicks`, and `--timeout`.
 

--- a/references/javascript.md
+++ b/references/javascript.md
@@ -35,7 +35,7 @@ const locator = terminal
 | Method | Use |
 | --- | --- |
 | `getByText(text, options?)` | Match text or regex. |
-| `getByStyle(style, options?)` | Match colors or attributes. |
+| `getByStyle(style, options?)` | Match colors, attributes, or an OSC 8 `link`. |
 | `any()` | Keep all matches. |
 | `unique()` | Require one match. |
 | `first()`, `last()`, `nth(index)` | Select a match. |

--- a/references/python.md
+++ b/references/python.md
@@ -33,7 +33,7 @@ locator = (
 | Method | Use |
 | --- | --- |
 | `get_by_text(text, **options)` | Match text or regex. |
-| `get_by_style(style, **options)` | Match colors or attributes. |
+| `get_by_style(style, **options)` | Match colors, attributes, or an OSC 8 `link`. |
 | `any()` | Keep all matches. |
 | `unique()` | Require one match. |
 | `first()`, `last()`, `nth(index)` | Select a match. |


### PR DESCRIPTION
Makes OSC 8 links assertable, not just readable.

> **Stacked on #181.** That PR records links on cells; this one adds the assertion surface. Review #181 first.

## Why

#181 makes links observable through `cells --json` and snapshots, but the style query has no link field. So a test that wants to check *where* a link points has to shell out and parse JSON:

```sh
tui-test cells 0 0 4 1 --json | jq -r '.data.cells[0].link'
```

That is precisely what the style query exists to avoid. `--fg`, `--underline-color` and the rest are all first-class; the link was not.

## What

`link` joins the other style properties, so it works everywhere they already do:

```sh
tui-test expect text "Docs" --link "https://example.com"
tui-test expect text "plain" --link ""
```

```ts
await term.getByStyle({ link: "https://example.com" }).expect();
```

```python
await term.get_by_style(TextStyle(link="https://example.com")).expect()
```

Because it is an ordinary style property it also composes with the `within`, `after` and `before` locator stages for free.

## An empty string is a requirement, not an absence

`--link ""` asks for a cell that links **nowhere**. That is how a test asserts `OSC 8 ;;` actually closed a link, rather than only that some *other* link is absent — a distinction that matters because a link running to the end of the row is exactly the bug #181 found in the xterm.js shim.

The `Option` already carries "the caller did not ask", which leaves the inner `String` free to mean something. Hence `Option<String>` rather than a bare `String` with a sentinel.

## Verification

Unit tests cover the matcher: matching URL, non-matching URL, empty-link-vs-linked-cell in both directions, and a style with no link still matching a linked cell (so this does not silently narrow existing queries). A CLI test pins that `--link ""` survives parsing as an empty string rather than collapsing to `None`.

Checked against a live session too, since a parse test would not catch a wiring mistake:

| assertion | exit |
| --- | --- |
| `expect text "LINK" --link "https://example.com"` | 0 |
| `expect text "LINK" --link "https://wrong.example"` | 1 |
| `expect text "plain" --link ""` | 0 |
| `expect text "plain" --link "https://example.com"` | 1 |
| `expect text "LINK" --link ""` | 1 |

`cargo test --workspace --features tui-test-rs/ghostty,tui-test-rs/rio,tui-test-rs/xtermjs` gives 633 passed, 0 failed. `cargo fmt --check` and both `clippy -D warnings` invocations are clean.
