### PR TITLE
feat: add Go support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,6 +2040,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "tui-test-go"
+version = "0.1.0-beta.3"
+dependencies = [
+ "tui-test-rs",
+]
+
+[[package]]
 name = "tui-test-node"
 version = "0.1.0-beta.3"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "bindings/go/native",
     "bindings/js",
     "bindings/python/native",
     "crates/tui-test",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tui-test
 
-`tui-test` controls, inspects, tests, and records real shell sessions and full-screen terminal apps on Windows, Linux, and macOS. Use it from the CLI or call the same engine from Rust, Python, or JavaScript. It works for AI agents that need structured access to terminal state, terminal automation, and terminal ui application testing.
+`tui-test` controls, inspects, tests, and records real shell sessions and full-screen terminal apps on Windows, Linux, and macOS. Use it from the CLI or call the same engine from Rust, Python, JavaScript, or Go. It works for AI agents that need structured access to terminal state, terminal automation, and terminal ui application testing.
 
 <p align="center">
   <a href="#installation">Installation</a>
@@ -52,12 +52,13 @@ You can also download a binary from [GitHub Releases](https://github.com/microso
 | Rust 1.90+ | `cargo add tui-test-rs@0.1.0-beta.3` | [docs.rs](https://docs.rs/tui-test-rs/latest/tui_test/) |
 | Python 3.8+ | `pip install --pre tui-test` | [Python API](bindings/python/README.md) |
 | Node 20+ | `npm install @microsoft/tui-test@beta` | [JavaScript API](bindings/js/README.md) |
+| Go 1.26+ | `go get github.com/microsoft/tui-test/bindings/go` | [Go installation and API](bindings/go/README.md) |
 
 Add the Rust `recording-raster` feature for APNG, GIF, and MP4 output. It uses installed fonts; `recording-font-jetbrains-mono*` bundles a font.
 
 ## Quick start
 
-The CLI and libraries expose the same terminal actions. Python, JavaScript, and Rust sessions run in-process and do not require the CLI.
+The CLI and libraries expose the same terminal actions. Python, JavaScript, Rust, and Go sessions run in-process and do not require the CLI. See [Go installation](bindings/go/README.md#install) for the Go binding's native build requirement.
 
 ### CLI
 
@@ -134,6 +135,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 | Rust | [docs.rs](https://docs.rs/tui-test-rs/latest/tui_test/) |
 | Python | [bindings/python/README.md](bindings/python/README.md) |
 | JavaScript | [bindings/js/README.md](bindings/js/README.md) |
+| Go | [bindings/go/README.md](bindings/go/README.md) |
 
 ## CLI reference
 

--- a/bindings/go/CONTRIBUTING.md
+++ b/bindings/go/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Building and maintaining the Go binding
+
+The [Go README](README.md) covers installation and application usage. This guide covers native builds and validation.
+
+## Architecture
+
+The public `tuitest` package at the module root owns clients, options, results, locators, and input helpers. Its `engine.go` adapter converts between public types and the internal native types.
+
+The `internal/native` package owns the C ABI, purego calls, native memory lifetimes, and library loading. It copies results into Go-owned values before releasing Rust allocations. Dependencies run from the public package into `internal/native`; the native package does not import the public package.
+
+The Rust adapter source stays in `native/` and delegates to the existing `tui-test` session registry and operations. Source builds load that adapter from the path in `TUI_TEST_GO_NATIVE_LIBRARY` and keep it loaded for the process lifetime.
+
+Terminal behavior, session synchronization, assertions, and recording remain in the Rust engine. Go owns option ergonomics, error presentation, and test cleanup. Keep new terminal behavior in the engine so language bindings share it.
+
+The native library and Go module must come from the same source revision. The C ABI is private to this binding. Native allocations must be released by their matching Rust functions, and native code must not retain Go pointers.
+
+## Build from source
+
+Install Go 1.26 or newer, Rust 1.90 or newer, Zig 0.16.0, and the native build tools required by your Rust target. Windows needs the MSVC build tools.
+
+From the repository root:
+
+```sh
+cargo build --locked -p tui-test-go
+```
+
+The native adapter enables the same terminal backends and recording features as the JavaScript and Python bindings. Zig is required by the Ghostty dependency.
+
+Set `TUI_TEST_GO_NATIVE_LIBRARY` to the built library before running a Go application or test. For Linux:
+
+```sh
+cd bindings/go
+TUI_TEST_GO_NATIVE_LIBRARY=../../target/debug/libtui_test_go.so CGO_ENABLED=0 go test ./...
+```
+
+On macOS, run from `bindings/go`:
+
+```sh
+TUI_TEST_GO_NATIVE_LIBRARY=../../target/debug/libtui_test_go.dylib CGO_ENABLED=0 go test ./...
+```
+
+On Windows amd64, run from the repository root:
+
+```powershell
+Set-Location bindings/go
+$env:TUI_TEST_GO_NATIVE_LIBRARY = (Resolve-Path ../../target/debug/tui_test_go.dll)
+$env:CGO_ENABLED = '0'
+go test ./...
+```
+
+For a release build, use `cargo build --release --locked -p tui-test-go` and point the environment variable at the library under `target/release`.
+
+To consume unpublished changes from another Go module, build the library as above, then add a local module replacement in the consuming project:
+
+```sh
+go mod edit -replace github.com/microsoft/tui-test/bindings/go=/absolute/path/to/tui-test/bindings/go
+go get github.com/microsoft/tui-test/bindings/go
+```
+
+## Validate changes
+
+After setting `TUI_TEST_GO_NATIVE_LIBRARY`, run these commands from `bindings/go`:
+
+```sh
+gofmt -l .
+go vet ./...
+go test ./...
+```
+
+`gofmt -l .` should produce no output. Also run `go test -race ./...` with cgo enabled and a C compiler available for Go's race detector; the binding itself does not require cgo.
+
+From the repository root, also run the Rust checks:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo clippy -p tui-test-rs --all-targets --no-default-features -- -D warnings
+cargo test --workspace -- --test-threads=1
+```
+
+`TestCloseInterruptsPendingWait` is explicitly skipped for the accepted shared-runtime limitation in [issue #207](https://github.com/microsoft/tui-test/issues/207). Its regression body remains in place. Remove the skip and run the test when the upstream fix is incorporated. The `CloseAll` interruption test remains active.

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -1,0 +1,149 @@
+# tui-test for Go
+
+Control, inspect, test, and record terminal apps from Go. The binding runs the Rust engine in your process and does not require the CLI.
+
+## Install
+
+With Go 1.26 or newer, add the binding to your project:
+
+```sh
+go get github.com/microsoft/tui-test/bindings/go
+```
+
+For an unpublished source checkout, build the native library and set `TUI_TEST_GO_NATIVE_LIBRARY` to its path before running the Go application. See [building and maintaining the Go binding](CONTRIBUTING.md). The source-built binding supports Windows, macOS, Linux, FreeBSD, and NetBSD on architectures supported by purego and the Rust engine.
+
+The binding loads the configured engine automatically on first use and keeps it loaded for the process lifetime. It does not download anything at runtime.
+
+## Quick start
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/microsoft/tui-test/bindings/go"
+)
+
+func main() {
+    terminal, err := tuitest.Ephemeral("example", tuitest.ClientOptions{})
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer terminal.CloseQuiet()
+
+    if _, err := terminal.Open(tuitest.OpenOptions{}); err != nil {
+        log.Print(err)
+        return
+    }
+    if err := terminal.Submit(tuitest.Ptr("echo hello")); err != nil {
+        log.Print(err)
+        return
+    }
+    if err := terminal.WaitCommand(tuitest.WaitOptions{}); err != nil {
+        log.Print(err)
+        return
+    }
+    output, err := terminal.GetOutput()
+    if err != nil {
+        log.Print(err)
+        return
+    }
+    if output != nil {
+        fmt.Print(*output)
+    }
+}
+```
+
+Use `Run(program, args, SpawnOptions{})` to launch an application directly. Use `Open(OpenOptions{})` when you need a shell and its command tracking.
+
+## Sessions and options
+
+`New(session, ClientOptions{})` creates a client for a named session. An empty name uses `TUI_TEST_SESSION`, falling back to `"default"`. `Ephemeral(prefix, options)` creates a unique name. Construction does not start a terminal; call `Open` or `Run`.
+
+Clients with the same name share the same in-process session. `Close` closes that session for every client. An existing client can open it again. `Sessions` lists live sessions, `CloseAll` closes them, and `Recording(session)` retrieves the automatic recording's asciicast content after closure. `OpenResult.Recording` contains its path.
+
+`ClientOptions` sets the backend, profile, timeouts, automatic recording, and assertion artifacts. `SpawnOptions` controls dimensions, working directory, environment, readiness, restart, retries, and per-launch overrides. `OpenOptions` embeds `SpawnOptions` and adds `Shell`.
+
+The default backend is Alacritty. The native adapter also enables Ghostty, Rio, and xterm.js. The default size is 80 columns by 30 rows. Automatic recording defaults to `RecordingAlways`; use `RecordingDisabled` or `RecordingOnFailure` to change it.
+
+Optional pointer fields distinguish omission from an explicit value. For example:
+
+```go
+options := tuitest.SpawnOptions{
+    Cols:      tuitest.Ptr(uint16(100)),
+    Rows:      tuitest.Ptr(uint16(40)),
+    WaitReady: tuitest.Ptr(false),
+}
+```
+
+Timeouts use `*time.Duration`. A nil timeout uses the client setting, then the engine default: 5 seconds for text and idle, or 30 seconds for command, exit, and ready. Explicit zero remains zero. Negative durations are rejected; positive fractions of a millisecond round upward.
+
+Methods block until their operation completes. Use goroutines for concurrent work. The Rust runtime serializes operations on each session. This API does not accept contexts or promise per-call cancellation.
+
+## API reference
+
+Use `go doc github.com/microsoft/tui-test/bindings/go` for the complete exported types and signatures. Methods return ordinary Go errors; getters preserve unavailable values with pointers where applicable.
+
+| Capability | Methods |
+| --- | --- |
+| Lifecycle | `Open`, `Run`, `Close`, `CloseQuiet`, `Session` |
+| Input | `Type`, `Write`, `Submit`, `Press`, `Resize`, `Signal`, `Kill` |
+| Keyboard | `Keyboard.Press`, `Down`, `Repeat`, `Up` |
+| Mouse | `Mouse.Click`, `Move`, `Down`, `Up`, `Drag`, `Scroll` |
+| Screen | `State`, `Text`, `Cells` |
+| Command state | `GetCommand`, `GetOutput`, `GetExitCode`, `GetCwd` |
+| Terminal state | `GetCursor`, `GetSize`, `GetTitle`, `GetClipboard`, `GetBellCount`, `GetBellEvents` |
+| Waits | `WaitTitle`, `WaitClipboard`, `WaitIdle`, `WaitCommand`, `WaitExit`, `WaitReady`, `WaitBell` |
+| Assertions | `ExpectTitle`, `ExpectExitCode`, `ExpectOutput`, `ExpectBellCount`, `ExpectSnapshot` |
+| Capture | `Screenshot`, `StartRecording`, `StopRecording` |
+
+Use `WaitCommand` after submitting a shell command, and `WaitExit` after running a program directly. `WaitIdle` only establishes that the screen stopped changing.
+
+### Locators
+
+`GetByText` and `GetByStyle` create lazy locators. Chaining returns a new locator and leaves the original unchanged. For example:
+
+```go
+ready := terminal.GetByText("Ready", tuitest.TextSelectorOptions{})
+err := ready.Last().Expect(tuitest.LocatorExpectOptions{})
+```
+
+Select matches with `Any`, `Unique`, `First`, `Last`, or `Nth`. Inspect them with `Locations`, `Location`, `Count`, or `All`. Use `Wait`, `Expect`, `Click`, and `Highlight` for actions. `Location` and `Click` require a unique match unless you select one explicitly.
+
+Nested text/style selectors support `Within`, `After`, and `Before` directions. Text selectors also support regular expressions, scrollback, and exact or normalized whitespace. Style pointer fields preserve explicit false values, such as `Bold: tuitest.Ptr(false)`.
+
+### Errors and artifacts
+
+Use `errors.As` with `*tuitest.Error` to inspect `Kind`, `Message`, `Operation`, and optional terminal diagnostics. Error kinds are `AssertionError`, `UsageError`, `NoSessionError`, and `InternalError`.
+
+Configure `ClientOptions.Artifacts` to attach text or SVG artifacts to assertion failures. Failure to capture an optional artifact does not replace the assertion error.
+
+### Recording and snapshots
+
+`StartRecording` supports asciinema, APNG, GIF, and MP4. File extensions select the format unless `RecordingOptions.Format` overrides it. `StopRecording` finishes the recording and returns its path. MP4 requires `ffmpeg` on the executable search path.
+
+`ExpectSnapshot` returns `SnapshotPassed`, `SnapshotWritten`, or `SnapshotUpdated`. Set `SnapshotOptions.Update` only when you intend to update the baseline. Snapshot options also control color and title inclusion and the snapshot working directory.
+
+## Test cleanup
+
+The `tuitesttest` package creates unique sessions and registers cleanup before starting the terminal. It closes the session when the test ends, including after a fatal test failure.
+
+```go
+func TestTerminal(t *testing.T) {
+    terminal := tuitesttest.New(t, tuitesttest.Options{})
+    if err := terminal.Submit(tuitest.Ptr("echo hello")); err != nil {
+        t.Fatal(err)
+    }
+    if err := terminal.WaitCommand(tuitest.WaitOptions{}); err != nil {
+        t.Fatal(err)
+    }
+}
+```
+
+Import `testing`, `github.com/microsoft/tui-test/bindings/go`, and `github.com/microsoft/tui-test/bindings/go/tuitesttest` in your test file. Pass client, spawn, shell, or program options through `tuitesttest.Options`. Configure `Client.Artifacts` to capture a failed test's terminal state. Each call has its own options, so parallel tests do not share mutable defaults.
+
+## Contributing
+
+See [building and testing the Go binding](CONTRIBUTING.md).

--- a/bindings/go/client.go
+++ b/bindings/go/client.go
@@ -1,0 +1,324 @@
+package tuitest
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// Client is a named handle. Handles with the same name share a session and can
+// be reused after that session closes. Its synchronous methods may run in goroutines.
+type Client struct {
+	session         string
+	options         ClientOptions
+	runtime         *nativeRuntime
+	Keyboard        *Keyboard
+	Mouse           *Mouse
+	artifactCounter atomic.Uint64
+}
+
+// New resolves an empty session from TUI_TEST_SESSION, then "default".
+func New(session string, options ClientOptions) (*Client, error) {
+	if session == "" {
+		session = os.Getenv("TUI_TEST_SESSION")
+	}
+	if session == "" {
+		session = "default"
+	}
+	if err := validateTimeouts(options.Timeouts); err != nil {
+		return nil, err
+	}
+	if err := validateClientOptions(options); err != nil {
+		return nil, err
+	}
+	options = cloneClientOptions(options)
+	runtime, err := newNativeRuntime(session, options.Recording)
+	if err != nil {
+		return nil, err
+	}
+	client := &Client{session: session, options: options, runtime: runtime}
+	client.Keyboard = &Keyboard{runtime: runtime}
+	client.Mouse = &Mouse{runtime: runtime}
+	return client, nil
+}
+
+func validateClientOptions(options ClientOptions) error {
+	switch options.Backend {
+	case "", Alacritty, Ghostty, Rio, XtermJS:
+	default:
+		return &Error{Kind: UsageError, Message: "unknown backend: " + string(options.Backend)}
+	}
+	if options.Recording != nil {
+		switch options.Recording.Mode {
+		case "", RecordingDisabled, RecordingOnFailure, RecordingAlways:
+		default:
+			return &Error{Kind: UsageError, Message: "unknown recording mode: " + string(options.Recording.Mode)}
+		}
+	}
+	return validateArtifactOptions(options.Artifacts)
+}
+func validateArtifactOptions(options *ArtifactOptions) error {
+	if options != nil {
+		switch options.OnFailure {
+		case "", ArtifactSVG, ArtifactText, ArtifactNone:
+		default:
+			return &Error{Kind: UsageError, Message: "unknown artifact mode: " + string(options.OnFailure)}
+		}
+		if options.OnFailure != ArtifactNone && options.Dir == "" {
+			return &Error{Kind: UsageError, Message: "artifact directory must not be empty"}
+		}
+	}
+	return nil
+}
+
+// Ephemeral creates a handle with a unique, filename-safe session name.
+func Ephemeral(prefix string, options ClientOptions) (*Client, error) {
+	if prefix == "" {
+		prefix = "go"
+	}
+	prefix = strings.Map(func(character rune) rune {
+		if character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || character >= '0' && character <= '9' || character == '-' || character == '_' {
+			return character
+		}
+		return '-'
+	}, prefix)
+	return New(prefix+"-"+rand.Text(), options)
+}
+func (client *Client) Session() string         { return client.session }
+func Sessions() ([]string, error)              { return nativeSessions() }
+func CloseAll() error                          { return nativeCloseAll() }
+func Recording(session string) (string, error) { return nativeRecording(session) }
+
+func clonePointer[Value any](value *Value) *Value {
+	if value == nil {
+		return nil
+	}
+	return Ptr(*value)
+}
+func cloneTimeouts(options Timeouts) Timeouts {
+	return Timeouts{clonePointer(options.Text), clonePointer(options.Idle), clonePointer(options.Command), clonePointer(options.Exit), clonePointer(options.Ready)}
+}
+func cloneClientOptions(options ClientOptions) ClientOptions {
+	options.Timeouts = cloneTimeouts(options.Timeouts)
+	options.Profile = clonePointer(options.Profile)
+	if options.Profile != nil {
+		options.Profile.Scrollback = clonePointer(options.Profile.Scrollback)
+	}
+	options.Recording = clonePointer(options.Recording)
+	options.Artifacts = clonePointer(options.Artifacts)
+	return options
+}
+func validateTimeouts(options Timeouts) error {
+	for _, timeout := range []*time.Duration{options.Text, options.Idle, options.Command, options.Exit, options.Ready} {
+		if timeout == nil {
+			continue
+		}
+		if _, err := timeoutMilliseconds(*timeout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func timeoutMilliseconds(timeout time.Duration) (uint64, error) {
+	return engineTimeoutMilliseconds(timeout)
+}
+
+func withTimeoutDefaults(options, defaults Timeouts) Timeouts {
+	if options.Text == nil {
+		options.Text = defaults.Text
+	}
+	if options.Idle == nil {
+		options.Idle = defaults.Idle
+	}
+	if options.Command == nil {
+		options.Command = defaults.Command
+	}
+	if options.Exit == nil {
+		options.Exit = defaults.Exit
+	}
+	if options.Ready == nil {
+		options.Ready = defaults.Ready
+	}
+	return options
+}
+
+func (client *Client) spawnOptions(options SpawnOptions) (SpawnOptions, error) {
+	if err := validateTimeouts(options.Timeouts); err != nil {
+		return options, err
+	}
+	if options.Backend == "" {
+		options.Backend = client.options.Backend
+	}
+	if options.Profile == nil {
+		options.Profile = client.options.Profile
+	}
+	options.Timeouts = withTimeoutDefaults(options.Timeouts, client.options.Timeouts)
+	if options.Cols == nil {
+		options.Cols = Ptr(uint16(80))
+	}
+	if options.Rows == nil {
+		options.Rows = Ptr(uint16(30))
+	}
+	return options, nil
+}
+func (client *Client) spawn(options SpawnOptions, action func(SpawnOptions) (OpenResult, error)) (OpenResult, error) {
+	resolved, err := client.spawnOptions(options)
+	if err != nil {
+		return OpenResult{}, err
+	}
+	for attempt := uint32(0); ; attempt++ {
+		result, err := action(resolved)
+		if err == nil || attempt == options.Retries {
+			return result, err
+		}
+	}
+}
+func (client *Client) Open(options OpenOptions) (OpenResult, error) {
+	return client.spawn(options.SpawnOptions, func(spawn SpawnOptions) (OpenResult, error) {
+		return client.runtime.open(OpenOptions{spawn, options.Shell})
+	})
+}
+func (client *Client) Run(program string, args []string, options SpawnOptions) (OpenResult, error) {
+	return client.spawn(options, func(spawn SpawnOptions) (OpenResult, error) { return client.runtime.run(program, args, spawn) })
+}
+func (client *Client) Close() error { return client.runtime.close() }
+
+// CloseQuiet attempts cleanup and reports success without returning diagnostics.
+func (client *Client) CloseQuiet() bool               { return client.Close() == nil }
+func (client *Client) Type(text string) error         { return client.runtime.typeText(text) }
+func (client *Client) Write(data string) error        { return client.runtime.write(data) }
+func (client *Client) Submit(text *string) error      { return client.runtime.submit(text) }
+func (client *Client) Press(keys ...string) error     { return client.Keyboard.Press(keys...) }
+func (client *Client) Resize(cols, rows uint16) error { return client.runtime.resize(cols, rows) }
+func (client *Client) Signal(name string) error       { return client.runtime.signal(name) }
+func (client *Client) Kill() error                    { return client.Signal("KILL") }
+func (client *Client) State() (State, error)          { return client.runtime.state() }
+func (client *Client) Text(options TextOptions) (string, error) {
+	return client.runtime.text(options.Full)
+}
+func (client *Client) Cells(x, y, width, height uint16) ([]Cell, error) {
+	return client.runtime.cells(x, y, width, height)
+}
+func (client *Client) GetCommand() (*string, error)        { return client.runtime.getCommand() }
+func (client *Client) GetOutput() (*string, error)         { return client.runtime.getOutput() }
+func (client *Client) GetExitCode() (*int32, error)        { return client.runtime.getExitCode() }
+func (client *Client) GetCwd() (*string, error)            { return client.runtime.getCwd() }
+func (client *Client) GetTitle() (*string, error)          { return client.runtime.getTitle() }
+func (client *Client) GetClipboard() (string, error)       { return client.runtime.getClipboard() }
+func (client *Client) GetCursor() (Cursor, error)          { return client.runtime.getCursor() }
+func (client *Client) GetSize() (Size, error)              { return client.runtime.getSize() }
+func (client *Client) GetBellCount() (uint64, error)       { return client.runtime.getBellCount() }
+func (client *Client) GetBellEvents() ([]BellEvent, error) { return client.runtime.getBellEvents() }
+
+// Screenshot returns terminal text when path is empty, otherwise the written path.
+func (client *Client) Screenshot(path string, options ScreenshotOptions) (string, error) {
+	if path == "" && options.Zoom != nil {
+		return "", &Error{Kind: UsageError, Message: "screenshot zoom requires a path"}
+	}
+	return client.runtime.screenshot(path, options)
+}
+func (client *Client) StartRecording(path string, options RecordingOptions) error {
+	return client.runtime.startRecording(path, options)
+}
+func (client *Client) StopRecording() (string, error) { return client.runtime.stopRecording() }
+
+func (client *Client) guard(operation string, err error) error {
+	var failure *Error
+	if !errors.As(err, &failure) || failure.Kind != AssertionError {
+		return err
+	}
+	copied := *failure
+	copied.Operation = operation
+	copied.Terminal = client.captureArtifact(failure.Message)
+	return &copied
+}
+func (client *Client) captureArtifact(message string) *TerminalArtifact {
+	options := client.options.Artifacts
+	if options == nil || options.OnFailure == ArtifactNone {
+		return nil
+	}
+	artifact := &TerminalArtifact{}
+	if _, terminal, found := strings.Cut(message, "Terminal content:\n"); found {
+		artifact.Text = strings.TrimRight(terminal, "\n")
+	}
+	if options.OnFailure == ArtifactText {
+		return artifact
+	}
+	if err := os.MkdirAll(options.Dir, 0755); err != nil {
+		artifact.CaptureError = err
+		return artifact
+	}
+	path := filepath.Join(options.Dir, fmt.Sprintf("tuitest-%d-%d.svg", time.Now().UnixNano(), client.artifactCounter.Add(1)))
+	artifact.Screenshot, artifact.CaptureError = client.Screenshot(path, ScreenshotOptions{})
+	return artifact
+}
+func (client *Client) wait(operation string, timeout, fallback *time.Duration, action func(*time.Duration) error) error {
+	resolved := timeout
+	if resolved == nil {
+		resolved = fallback
+	}
+	if resolved != nil {
+		if _, err := timeoutMilliseconds(*resolved); err != nil {
+			return err
+		}
+	}
+	return client.guard(operation, action(resolved))
+}
+func (client *Client) WaitIdle(options WaitOptions) error {
+	return client.wait("waitIdle", options.Timeout, client.options.Timeouts.Idle, client.runtime.waitIdle)
+}
+func (client *Client) WaitCommand(options WaitOptions) error {
+	return client.wait("waitCommand", options.Timeout, client.options.Timeouts.Command, client.runtime.waitCommand)
+}
+func (client *Client) WaitExit(options WaitOptions) error {
+	return client.wait("waitExit", options.Timeout, client.options.Timeouts.Exit, client.runtime.waitExit)
+}
+func (client *Client) WaitReady(options WaitOptions) error {
+	return client.wait("waitReady", options.Timeout, client.options.Timeouts.Ready, client.runtime.waitReady)
+}
+func (client *Client) WaitBell(options WaitOptions) error {
+	return client.wait("waitBell", options.Timeout, client.options.Timeouts.Text, client.runtime.waitBell)
+}
+func (client *Client) WaitTitle(text string, options TitleOptions) error {
+	return client.wait("waitTitle", options.Timeout, client.options.Timeouts.Text, func(timeout *time.Duration) error {
+		options.Timeout = timeout
+		return client.runtime.waitTitle(text, options)
+	})
+}
+func (client *Client) WaitClipboard(options ClipboardWaitOptions) error {
+	return client.wait("waitClipboard", options.Timeout, client.options.Timeouts.Text, func(timeout *time.Duration) error {
+		options.Timeout = timeout
+		return client.runtime.waitClipboard(options)
+	})
+}
+func (client *Client) ExpectTitle(text string, options TitleOptions) error {
+	return client.wait("expectTitle", options.Timeout, client.options.Timeouts.Text, func(timeout *time.Duration) error {
+		options.Timeout = timeout
+		return client.runtime.expectTitle(text, options)
+	})
+}
+func (client *Client) ExpectExitCode(code int32, options WaitOptions) error {
+	return client.wait("expectExitCode", options.Timeout, client.options.Timeouts.Command, func(timeout *time.Duration) error { return client.runtime.expectExitCode(code, timeout) })
+}
+func (client *Client) ExpectOutput(text string, options OutputOptions) error {
+	return client.guard("expectOutput", client.runtime.expectOutput(text, options.Regex))
+}
+func (client *Client) ExpectBellCount(count uint64, options WaitOptions) error {
+	return client.wait("expectBellCount", options.Timeout, client.options.Timeouts.Text, func(timeout *time.Duration) error { return client.runtime.expectBellCount(count, timeout) })
+}
+func (client *Client) ExpectSnapshot(name string, options SnapshotOptions) (SnapshotResult, error) {
+	if options.Cwd == "" {
+		directory, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("snapshot working directory: %w", err)
+		}
+		options.Cwd = directory
+	}
+	result, err := client.runtime.snapshot(name, options)
+	return result, client.guard("expectSnapshot", err)
+}

--- a/bindings/go/engine.go
+++ b/bindings/go/engine.go
@@ -1,0 +1,283 @@
+package tuitest
+
+import (
+	"errors"
+	"time"
+
+	"github.com/microsoft/tui-test/bindings/go/internal/native"
+)
+
+type nativeRuntime struct{ session *native.Session }
+
+func newNativeRuntime(name string, recording *AutomaticRecording) (*nativeRuntime, error) {
+	var nativeRecording *native.AutomaticRecording
+	if recording != nil {
+		nativeRecording = &native.AutomaticRecording{Mode: native.RecordingMode(recording.Mode), Directory: recording.Directory}
+	}
+	session, err := native.NewSession(name, nativeRecording)
+	if err != nil {
+		return nil, engineError(err)
+	}
+	return &nativeRuntime{session: session}, nil
+}
+func engineError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var failure *native.Error
+	if errors.As(err, &failure) {
+		return &Error{Kind: ErrorKind(failure.Kind), Message: failure.Message}
+	}
+	return &Error{Kind: InternalError, Message: err.Error()}
+}
+func engineTimeoutMilliseconds(timeout time.Duration) (uint64, error) {
+	value, err := native.Milliseconds(timeout)
+	return value, engineError(err)
+}
+func nativeSessions() ([]string, error) {
+	value, err := native.Sessions()
+	return value, engineError(err)
+}
+func nativeCloseAll() error { return engineError(native.CloseAll()) }
+func nativeRecording(session string) (string, error) {
+	value, err := native.Recording(session)
+	return value, engineError(err)
+}
+func (runtime *nativeRuntime) close() error { return engineError(runtime.session.Close()) }
+func (runtime *nativeRuntime) typeText(text string) error {
+	return engineError(runtime.session.TypeText(text))
+}
+func (runtime *nativeRuntime) write(text string) error {
+	return engineError(runtime.session.Write(text))
+}
+func (runtime *nativeRuntime) submit(text *string) error {
+	return engineError(runtime.session.Submit(text))
+}
+func (runtime *nativeRuntime) signal(name string) error {
+	return engineError(runtime.session.Signal(name))
+}
+func (runtime *nativeRuntime) resize(cols, rows uint16) error {
+	return engineError(runtime.session.Resize(cols, rows))
+}
+func (runtime *nativeRuntime) key(keys []string, action uint32) error {
+	return engineError(runtime.session.Key(keys, action))
+}
+func (runtime *nativeRuntime) waitIdle(timeout *time.Duration) error {
+	return engineError(runtime.session.WaitIdle(timeout))
+}
+func (runtime *nativeRuntime) waitCommand(timeout *time.Duration) error {
+	return engineError(runtime.session.WaitCommand(timeout))
+}
+func (runtime *nativeRuntime) waitExit(timeout *time.Duration) error {
+	return engineError(runtime.session.WaitExit(timeout))
+}
+func (runtime *nativeRuntime) waitReady(timeout *time.Duration) error {
+	return engineError(runtime.session.WaitReady(timeout))
+}
+func (runtime *nativeRuntime) waitBell(timeout *time.Duration) error {
+	return engineError(runtime.session.WaitBell(timeout))
+}
+func (runtime *nativeRuntime) waitTitle(text string, options TitleOptions) error {
+	return engineError(runtime.session.WaitTitle(text, native.TitleOptions(options)))
+}
+func (runtime *nativeRuntime) expectTitle(text string, options TitleOptions) error {
+	return engineError(runtime.session.ExpectTitle(text, native.TitleOptions(options)))
+}
+func (runtime *nativeRuntime) waitClipboard(options ClipboardWaitOptions) error {
+	return engineError(runtime.session.WaitClipboard(native.ClipboardWaitOptions(options)))
+}
+func (runtime *nativeRuntime) expectExitCode(code int32, timeout *time.Duration) error {
+	return engineError(runtime.session.ExpectExitCode(code, timeout))
+}
+func (runtime *nativeRuntime) expectOutput(text string, regex bool) error {
+	return engineError(runtime.session.ExpectOutput(text, regex))
+}
+func (runtime *nativeRuntime) expectBellCount(count uint64, timeout *time.Duration) error {
+	return engineError(runtime.session.ExpectBellCount(count, timeout))
+}
+func (runtime *nativeRuntime) startRecording(path string, options RecordingOptions) error {
+	return engineError(runtime.session.StartRecording(path, engineRecordingOptions(options)))
+}
+func (runtime *nativeRuntime) mouseClick(options MouseClickOptions) error {
+	return engineError(runtime.session.MouseClick(engineMouseClickOptions(options)))
+}
+func (runtime *nativeRuntime) mouseMove(column, row uint16) error {
+	return engineError(runtime.session.MouseMove(column, row))
+}
+func (runtime *nativeRuntime) mouseDown(column, row uint16, options MouseButtonOptions) error {
+	return engineError(runtime.session.MouseDown(column, row, engineMouseOptions(options)))
+}
+func (runtime *nativeRuntime) mouseUp(column, row uint16, options MouseButtonOptions) error {
+	return engineError(runtime.session.MouseUp(column, row, engineMouseOptions(options)))
+}
+func (runtime *nativeRuntime) mouseDrag(fromColumn, fromRow, toColumn, toRow uint16, options MouseButtonOptions) error {
+	return engineError(runtime.session.MouseDrag(fromColumn, fromRow, toColumn, toRow, engineMouseOptions(options)))
+}
+func (runtime *nativeRuntime) mouseScroll(direction ScrollDirection, amount uint32) error {
+	return engineError(runtime.session.MouseScroll(native.ScrollDirection(direction), amount))
+}
+func (runtime *nativeRuntime) waitLocator(stages []locatorStage, hidden bool, timeout *time.Duration) error {
+	return engineError(runtime.session.WaitLocator(engineLocatorStages(stages), hidden, timeout))
+}
+func (runtime *nativeRuntime) expectLocator(stages []locatorStage, options LocatorExpectOptions) error {
+	return engineError(runtime.session.ExpectLocator(engineLocatorStages(stages), native.LocatorExpectOptions(options)))
+}
+func (runtime *nativeRuntime) clickLocator(stages []locatorStage, options LocatorClickOptions) error {
+	return engineError(runtime.session.ClickLocator(engineLocatorStages(stages), engineLocatorClickOptions(options)))
+}
+func (runtime *nativeRuntime) highlightLocator(stages []locatorStage, timeout *time.Duration) error {
+	return engineError(runtime.session.HighlightLocator(engineLocatorStages(stages), timeout))
+}
+func (runtime *nativeRuntime) open(options OpenOptions) (OpenResult, error) {
+	value, err := runtime.session.Open(engineOpenOptions(options))
+	return OpenResult(value), engineError(err)
+}
+func (runtime *nativeRuntime) run(program string, args []string, options SpawnOptions) (OpenResult, error) {
+	value, err := runtime.session.Run(program, args, engineSpawnOptions(options))
+	return OpenResult(value), engineError(err)
+}
+func (runtime *nativeRuntime) state() (State, error) {
+	value, err := runtime.session.State()
+	return engineState(value), engineError(err)
+}
+func (runtime *nativeRuntime) text(full bool) (string, error) {
+	value, err := runtime.session.Text(full)
+	return value, engineError(err)
+}
+func (runtime *nativeRuntime) cells(column, row, width, height uint16) ([]Cell, error) {
+	value, err := runtime.session.Cells(column, row, width, height)
+	return engineCells(value), engineError(err)
+}
+func (runtime *nativeRuntime) getCursor() (Cursor, error) {
+	value, err := runtime.session.GetCursor()
+	return Cursor(value), engineError(err)
+}
+func (runtime *nativeRuntime) getSize() (Size, error) {
+	value, err := runtime.session.GetSize()
+	return Size(value), engineError(err)
+}
+func (runtime *nativeRuntime) getExitCode() (*int32, error) {
+	value, err := runtime.session.GetExitCode()
+	return value, engineError(err)
+}
+func (runtime *nativeRuntime) getBellCount() (uint64, error) {
+	value, err := runtime.session.GetBellCount()
+	return value, engineError(err)
+}
+func (runtime *nativeRuntime) getBellEvents() ([]BellEvent, error) {
+	value, err := runtime.session.GetBellEvents()
+	return engineBellEvents(value), engineError(err)
+}
+func (runtime *nativeRuntime) getCommand() (*string, error) {
+	value, err := runtime.session.GetCommand()
+	return value, engineError(err)
+}
+func (runtime *nativeRuntime) getOutput() (*string, error) {
+	value, err := runtime.session.GetOutput()
+	return value, engineError(err)
+}
+func (runtime *nativeRuntime) getCwd() (*string, error) {
+	value, err := runtime.session.GetCwd()
+	return value, engineError(err)
+}
+func (runtime *nativeRuntime) getTitle() (*string, error) {
+	value, err := runtime.session.GetTitle()
+	return value, engineError(err)
+}
+func (runtime *nativeRuntime) getClipboard() (string, error) {
+	value, err := runtime.session.GetClipboard()
+	return value, engineError(err)
+}
+func (runtime *nativeRuntime) stopRecording() (string, error) {
+	value, err := runtime.session.StopRecording()
+	return value, engineError(err)
+}
+func (runtime *nativeRuntime) screenshot(path string, options ScreenshotOptions) (string, error) {
+	value, err := runtime.session.Screenshot(path, native.ScreenshotOptions(options))
+	return value, engineError(err)
+}
+func (runtime *nativeRuntime) snapshot(name string, options SnapshotOptions) (SnapshotResult, error) {
+	value, err := runtime.session.Snapshot(name, native.SnapshotOptions(options))
+	return SnapshotResult(value), engineError(err)
+}
+func (runtime *nativeRuntime) findLocator(stages []locatorStage) ([]TextMatch, error) {
+	value, err := runtime.session.FindLocator(engineLocatorStages(stages))
+	return engineMatches(value), engineError(err)
+}
+
+func engineSpawnOptions(options SpawnOptions) native.SpawnOptions {
+	var profile *native.Profile
+	if options.Profile != nil {
+		profile = &native.Profile{Scrollback: options.Profile.Scrollback, Colors: native.Colors(options.Profile.Colors)}
+	}
+	return native.SpawnOptions{Backend: native.Backend(options.Backend), Cols: options.Cols, Rows: options.Rows, Cwd: options.Cwd, Env: options.Env, WaitReady: options.WaitReady, Restart: options.Restart, Profile: profile, Timeouts: native.Timeouts(options.Timeouts)}
+}
+func engineOpenOptions(options OpenOptions) native.OpenOptions {
+	return native.OpenOptions{SpawnOptions: engineSpawnOptions(options.SpawnOptions), Shell: native.Shell(options.Shell)}
+}
+func engineRecordingOptions(options RecordingOptions) native.RecordingOptions {
+	return native.RecordingOptions{Format: native.RecordingFormat(options.Format), FPS: options.FPS, Speed: options.Speed, IdleTimeLimit: options.IdleTimeLimit, Zoom: options.Zoom}
+}
+func engineMouseOptions(options MouseButtonOptions) native.MouseButtonOptions {
+	return native.MouseButtonOptions{Button: native.MouseButton(options.Button), Alt: options.Alt, Ctrl: options.Ctrl, Shift: options.Shift}
+}
+func engineMouseClickOptions(options MouseClickOptions) native.MouseClickOptions {
+	return native.MouseClickOptions{MouseButtonOptions: engineMouseOptions(options.MouseButtonOptions), X: options.X, Y: options.Y, OnText: options.OnText, Clicks: options.Clicks}
+}
+func engineLocatorClickOptions(options LocatorClickOptions) native.LocatorClickOptions {
+	return native.LocatorClickOptions{MouseButtonOptions: engineMouseOptions(options.MouseButtonOptions), Clicks: options.Clicks, Timeout: options.Timeout}
+}
+func engineTextStyle(style TextStyle) native.TextStyle {
+	var underline *native.UnderlineStyle
+	if style.UnderlineStyle != nil {
+		underline = Ptr(native.UnderlineStyle(*style.UnderlineStyle))
+	}
+	return native.TextStyle{Foreground: style.Foreground, Background: style.Background, Bold: style.Bold, Dim: style.Dim, Italic: style.Italic, UnderlineStyle: underline, UnderlineColor: style.UnderlineColor, Inverse: style.Inverse, Hidden: style.Hidden, Strikethrough: style.Strikethrough, Blink: style.Blink}
+}
+func engineLocatorStages(stages []locatorStage) []native.LocatorStage {
+	converted := make([]native.LocatorStage, len(stages))
+	for index, stage := range stages {
+		converted[index] = native.LocatorStage{Kind: stage.kind, Text: stage.text, TextOptions: native.TextSelectorOptions{Regex: stage.textOptions.Regex, Full: stage.textOptions.Full, Whitespace: native.Whitespace(stage.textOptions.Whitespace), Direction: native.Direction(stage.textOptions.Direction)}, Style: engineTextStyle(stage.style), StyleOptions: native.StyleSelectorOptions{Full: stage.styleOptions.Full, Direction: native.Direction(stage.styleOptions.Direction)}, Occurrence: stage.occurrence, Nth: stage.nth}
+	}
+	return converted
+}
+func engineState(state native.State) State {
+	return State{SessionShell: state.SessionShell, Cols: state.Cols, Rows: state.Rows, Cursor: Cursor(state.Cursor), Title: state.Title, Cwd: state.Cwd, LastCommand: state.LastCommand, LastExit: state.LastExit, Exited: state.Exited, Ready: state.Ready, BellCount: state.BellCount, Timeouts: EffectiveTimeouts(state.Timeouts), Text: state.Text}
+}
+func engineCells(cells []native.Cell) []Cell {
+	if cells == nil {
+		return nil
+	}
+
+	converted := make([]Cell, len(cells))
+	for index, cell := range cells {
+		converted[index] = Cell{X: cell.X, Y: cell.Y, Char: cell.Char, FG: Color(cell.FG), BG: Color(cell.BG), Bold: cell.Bold, Dim: cell.Dim, Italic: cell.Italic, Inverse: cell.Inverse, Invisible: cell.Invisible, Strike: cell.Strike, Blink: cell.Blink, Underline: cell.Underline, UnderlineStyle: UnderlineStyle(cell.UnderlineStyle), UnderlineColor: Color(cell.UnderlineColor)}
+	}
+	return converted
+}
+func engineMatches(matches []native.TextMatch) []TextMatch {
+	if matches == nil {
+		return nil
+	}
+
+	converted := make([]TextMatch, len(matches))
+	for index, match := range matches {
+		spans := make([]TextSpan, len(match.Spans))
+		for spanIndex, span := range match.Spans {
+			spans[spanIndex] = TextSpan(span)
+		}
+		converted[index] = TextMatch{Text: match.Text, Start: TextPosition(match.Start), End: TextPosition(match.End), Spans: spans}
+	}
+	return converted
+}
+func engineBellEvents(events []native.BellEvent) []BellEvent {
+	if events == nil {
+		return nil
+	}
+
+	converted := make([]BellEvent, len(events))
+	for index, event := range events {
+		converted[index] = BellEvent(event)
+	}
+	return converted
+}

--- a/bindings/go/examples/smoke/main.go
+++ b/bindings/go/examples/smoke/main.go
@@ -1,0 +1,66 @@
+// The smoke consumer runs itself in child mode, so it needs no external shell.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"time"
+
+	tuitest "github.com/microsoft/tui-test/bindings/go"
+)
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "--child" {
+		fmt.Println("go-binding-ready")
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			if scanner.Text() == "quit" {
+				return
+			}
+			fmt.Println("echo:" + scanner.Text())
+		}
+		return
+	}
+	if err := smoke(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Println("Go binding smoke passed")
+}
+
+func smoke() error {
+	terminal, err := tuitest.Ephemeral("smoke", tuitest.ClientOptions{Recording: &tuitest.AutomaticRecording{Mode: tuitest.RecordingDisabled}})
+	if err != nil {
+		return fmt.Errorf("create smoke terminal: %w", err)
+	}
+	defer terminal.CloseQuiet()
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate smoke executable: %w", err)
+	}
+	if _, err = terminal.Run(executable, []string{"--child"}, tuitest.SpawnOptions{WaitReady: tuitest.Ptr(false)}); err != nil {
+		return fmt.Errorf("run smoke child: %w", err)
+	}
+	return exerciseTerminal(terminal)
+}
+
+func exerciseTerminal(terminal *tuitest.Client) error {
+	timeout := 10 * time.Second
+	if err := terminal.GetByText("go-binding-ready", tuitest.TextSelectorOptions{}).Expect(tuitest.LocatorExpectOptions{Timeout: &timeout}); err != nil {
+		return fmt.Errorf("wait for child readiness: %w", err)
+	}
+	if err := terminal.Submit(tuitest.Ptr("hello")); err != nil {
+		return fmt.Errorf("submit child input: %w", err)
+	}
+	if err := terminal.GetByText("echo:hello", tuitest.TextSelectorOptions{}).Expect(tuitest.LocatorExpectOptions{Timeout: &timeout}); err != nil {
+		return fmt.Errorf("expect child response: %w", err)
+	}
+	if err := terminal.Submit(tuitest.Ptr("quit")); err != nil {
+		return fmt.Errorf("request child exit: %w", err)
+	}
+	if err := terminal.WaitExit(tuitest.WaitOptions{Timeout: &timeout}); err != nil {
+		return fmt.Errorf("wait for child exit: %w", err)
+	}
+	return nil
+}

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/microsoft/tui-test/bindings/go
+
+go 1.26
+
+require github.com/ebitengine/purego v0.11.0

--- a/bindings/go/go.sum
+++ b/bindings/go/go.sum
@@ -1,0 +1,2 @@
+github.com/ebitengine/purego v0.11.0 h1:jhp/D+Nyv7UUW8HAcmcjt2N2rYrYi9m3SL21k0Ua/NI=
+github.com/ebitengine/purego v0.11.0/go.mod h1:DCHPP08djqhNSoTfImcnHYQRZmd0qhakvrozqaEYhGQ=

--- a/bindings/go/input.go
+++ b/bindings/go/input.go
@@ -1,0 +1,27 @@
+package tuitest
+
+// Keyboard sends terminal key events, including separate press and release events.
+type Keyboard struct{ runtime *nativeRuntime }
+
+func (keyboard *Keyboard) Press(keys ...string) error  { return keyboard.runtime.key(keys, 0) }
+func (keyboard *Keyboard) Down(keys ...string) error   { return keyboard.runtime.key(keys, 1) }
+func (keyboard *Keyboard) Repeat(keys ...string) error { return keyboard.runtime.key(keys, 2) }
+func (keyboard *Keyboard) Up(keys ...string) error     { return keyboard.runtime.key(keys, 3) }
+
+// Mouse sends coordinates in terminal cells.
+type Mouse struct{ runtime *nativeRuntime }
+
+func (mouse *Mouse) Click(options MouseClickOptions) error { return mouse.runtime.mouseClick(options) }
+func (mouse *Mouse) Move(x, y uint16) error                { return mouse.runtime.mouseMove(x, y) }
+func (mouse *Mouse) Down(x, y uint16, options MouseButtonOptions) error {
+	return mouse.runtime.mouseDown(x, y, options)
+}
+func (mouse *Mouse) Up(x, y uint16, options MouseButtonOptions) error {
+	return mouse.runtime.mouseUp(x, y, options)
+}
+func (mouse *Mouse) Drag(x1, y1, x2, y2 uint16, options MouseButtonOptions) error {
+	return mouse.runtime.mouseDrag(x1, y1, x2, y2, options)
+}
+func (mouse *Mouse) Scroll(direction ScrollDirection, amount uint32) error {
+	return mouse.runtime.mouseScroll(direction, amount)
+}

--- a/bindings/go/integration_test.go
+++ b/bindings/go/integration_test.go
@@ -1,0 +1,336 @@
+package tuitest_test
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	tuitest "github.com/microsoft/tui-test/bindings/go"
+)
+
+func TestTerminalProcess(t *testing.T) {
+	if !slices.Contains(os.Args, "--tui-go-child") {
+		return
+	}
+	fmt.Print("\x1b[2J\x1b[Hgo-ready\r\nitem item\r\n\x1b[1mstyled\x1b[0m plain\r\n界 café\r\n")
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		switch scanner.Text() {
+		case "quit":
+			os.Exit(0)
+		case "events":
+			fmt.Print("\x1b]2;Go title\x07\x1b]52;c;Z28tY2xpcGJvYXJk\x07\x07\r\nevents-done\r\n")
+		default:
+			fmt.Printf("received:%s\r\n", scanner.Text())
+		}
+	}
+	os.Exit(0)
+}
+
+func newTerminal(t *testing.T, options tuitest.ClientOptions) *tuitest.Client {
+	t.Helper()
+	terminal := newClient(t, options)
+	runTerminal(t, terminal, tuitest.SpawnOptions{})
+	return terminal
+}
+
+func newClient(t *testing.T, options tuitest.ClientOptions) *tuitest.Client {
+	t.Helper()
+	if options.Recording == nil {
+		options.Recording = &tuitest.AutomaticRecording{Mode: tuitest.RecordingDisabled}
+	}
+	terminal, err := tuitest.Ephemeral(t.Name(), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := terminal.Close(); err != nil {
+			t.Errorf("close terminal: %v", err)
+		}
+	})
+	return terminal
+}
+func runTerminal(t *testing.T, terminal *tuitest.Client, options tuitest.SpawnOptions) {
+	t.Helper()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	options.WaitReady = tuitest.Ptr(false)
+	if _, err = terminal.Run(executable, []string{"-test.run=^TestTerminalProcess$", "--", "--tui-go-child"}, options); err != nil {
+		t.Fatal(err)
+	}
+	if err = terminal.GetByText("go-ready", tuitest.TextSelectorOptions{}).Expect(tuitest.LocatorExpectOptions{Timeout: tuitest.Ptr(10 * time.Second)}); err != nil {
+		t.Fatal(err)
+	}
+}
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+func requireKind(t *testing.T, err error, kind tuitest.ErrorKind) {
+	t.Helper()
+	var failure *tuitest.Error
+	if !errors.As(err, &failure) || failure.Kind != kind {
+		t.Fatalf("expected %s error, got %v", kind, err)
+	}
+}
+
+func TestLocatorsPreserveSelection(t *testing.T) {
+	terminal := newTerminal(t, tuitest.ClientOptions{})
+	items := terminal.GetByText("item", tuitest.TextSelectorOptions{})
+	count, err := items.Count()
+	requireNoError(t, err)
+	if count != 2 {
+		t.Fatalf("item count=%d", count)
+	}
+	_, err = items.Location()
+	requireKind(t, err, tuitest.AssertionError)
+	first, err := items.First().Location()
+	requireNoError(t, err)
+	last, err := items.Last().Location()
+	requireNoError(t, err)
+	if first.Start.Column >= last.Start.Column {
+		t.Fatalf("unordered locations: %+v %+v", first, last)
+	}
+	requireNoError(t, items.Highlight(tuitest.WaitOptions{}))
+	requireNoError(t, items.First().Click(tuitest.LocatorClickOptions{}))
+	requireNoError(t, terminal.GetByText("absent", tuitest.TextSelectorOptions{}).Wait(tuitest.LocatorWaitOptions{State: tuitest.Hidden, Timeout: tuitest.Ptr(time.Duration(0))}))
+}
+
+func TestLocatorEnumerationAndRelativeQueries(t *testing.T) {
+	terminal := newTerminal(t, tuitest.ClientOptions{})
+	items := terminal.GetByText("item", tuitest.TextSelectorOptions{})
+	all, err := items.All()
+	requireNoError(t, err)
+	for index, locator := range all {
+		actual, locationErr := locator.Location()
+		requireNoError(t, locationErr)
+		selected, selectedErr := items.Nth(uint32(index)).Location()
+		requireNoError(t, selectedErr)
+		if actual.Start != selected.Start {
+			t.Fatalf("all[%d]=%+v; nth=%+v", index, actual, selected)
+		}
+	}
+	count, err := items.Count()
+	requireNoError(t, err)
+	if count != 2 {
+		t.Fatal("selection mutated original locator")
+	}
+	requireNoError(t, terminal.GetByText("item item", tuitest.TextSelectorOptions{}).GetByText("item", tuitest.TextSelectorOptions{}).Nth(1).Expect(tuitest.LocatorExpectOptions{}))
+	requireNoError(t, items.First().GetByText("item", tuitest.TextSelectorOptions{Direction: tuitest.After}).Expect(tuitest.LocatorExpectOptions{}))
+}
+
+func TestStylesAndWideCellCoordinates(t *testing.T) {
+	terminal := newTerminal(t, tuitest.ClientOptions{})
+	bold := true
+	styled := terminal.GetByStyle(tuitest.TextStyle{Bold: &bold}, tuitest.StyleSelectorOptions{})
+	bold = false
+	requireNoError(t, styled.GetByText("styled", tuitest.TextSelectorOptions{}).Expect(tuitest.LocatorExpectOptions{}))
+	requireNoError(t, terminal.GetByText("plain", tuitest.TextSelectorOptions{}).GetByStyle(tuitest.TextStyle{Bold: tuitest.Ptr(false)}, tuitest.StyleSelectorOptions{}).Expect(tuitest.LocatorExpectOptions{}))
+	wide, err := terminal.GetByText("界", tuitest.TextSelectorOptions{}).Location()
+	requireNoError(t, err)
+	if wide.Start.Column != 0 || wide.Start.Row != 3 {
+		t.Fatalf("unexpected wide cell coordinates: %+v", wide.Start)
+	}
+	cells, err := terminal.Cells(0, 3, 2, 1)
+	requireNoError(t, err)
+	if len(cells) != 2 || cells[0].Char != "界" || cells[1].Char != "" {
+		t.Fatalf("wide cells=%+v", cells)
+	}
+}
+
+func TestInputAndState(t *testing.T) {
+	terminal := newTerminal(t, tuitest.ClientOptions{})
+	state, err := terminal.State()
+	requireNoError(t, err)
+	if state.Cols != 80 || state.Rows != 30 {
+		t.Fatalf("default size=%dx%d", state.Cols, state.Rows)
+	}
+	requireNoError(t, terminal.Resize(90, 32))
+	size, err := terminal.GetSize()
+	requireNoError(t, err)
+	if size.Cols != 90 || size.Rows != 32 {
+		t.Fatalf("resized size=%+v", size)
+	}
+	_, err = terminal.GetCursor()
+	requireNoError(t, err)
+	_, err = terminal.GetCommand()
+	requireNoError(t, err)
+	_, err = terminal.GetOutput()
+	requireNoError(t, err)
+	_, err = terminal.GetExitCode()
+	requireNoError(t, err)
+	_, err = terminal.GetCwd()
+	requireNoError(t, err)
+	requireNoError(t, terminal.Type("hello"))
+	requireNoError(t, terminal.Press("Enter"))
+	requireNoError(t, terminal.GetByText("received:hello", tuitest.TextSelectorOptions{}).Expect(tuitest.LocatorExpectOptions{}))
+	requireNoError(t, terminal.Submit(tuitest.Ptr("quit")))
+	requireNoError(t, terminal.WaitExit(tuitest.WaitOptions{Timeout: tuitest.Ptr(10 * time.Second)}))
+}
+
+func TestTerminalEvents(t *testing.T) {
+	terminal := newTerminal(t, tuitest.ClientOptions{})
+	requireNoError(t, terminal.Submit(tuitest.Ptr("events")))
+	requireNoError(t, terminal.WaitTitle("Go title", tuitest.TitleOptions{}))
+	requireNoError(t, terminal.ExpectTitle("^Go", tuitest.TitleOptions{Regex: true}))
+	requireNoError(t, terminal.WaitClipboard(tuitest.ClipboardWaitOptions{Text: tuitest.Ptr("go-clipboard")}))
+	title, err := terminal.GetTitle()
+	requireNoError(t, err)
+	if title == nil || *title != "Go title" {
+		t.Fatalf("title=%v", title)
+	}
+	clipboard, err := terminal.GetClipboard()
+	requireNoError(t, err)
+	if clipboard != "go-clipboard" {
+		t.Fatalf("clipboard=%q", clipboard)
+	}
+	requireNoError(t, terminal.ExpectBellCount(1, tuitest.WaitOptions{}))
+	events, err := terminal.GetBellEvents()
+	requireNoError(t, err)
+	if len(events) != 1 || events[0].Sequence != 1 {
+		t.Fatalf("bell events=%+v", events)
+	}
+	count, err := terminal.GetBellCount()
+	requireNoError(t, err)
+	if count != 1 {
+		t.Fatalf("bell count=%d", count)
+	}
+}
+
+func TestScreenshotsAndSnapshots(t *testing.T) {
+	terminal := newTerminal(t, tuitest.ClientOptions{})
+	text, err := terminal.Screenshot("", tuitest.ScreenshotOptions{})
+	requireNoError(t, err)
+	if !strings.Contains(text, "go-ready") {
+		t.Fatalf("screenshot omitted terminal text: %.100s", text)
+	}
+	directory := t.TempDir()
+	path, err := terminal.Screenshot(filepath.Join(directory, "terminal.svg"), tuitest.ScreenshotOptions{})
+	requireNoError(t, err)
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Fatal(statErr)
+	}
+	snapshot, err := terminal.ExpectSnapshot("terminal", tuitest.SnapshotOptions{Cwd: directory, Update: true})
+	requireNoError(t, err)
+	if snapshot != tuitest.SnapshotWritten && snapshot != tuitest.SnapshotUpdated {
+		t.Fatalf("snapshot=%s", snapshot)
+	}
+	_, err = terminal.ExpectSnapshot("terminal", tuitest.SnapshotOptions{Cwd: directory})
+	requireNoError(t, err)
+	requireNoError(t, terminal.Submit(tuitest.Ptr("quit")))
+	requireNoError(t, terminal.WaitExit(tuitest.WaitOptions{Timeout: tuitest.Ptr(10 * time.Second)}))
+}
+
+func TestNamedHandlesReopen(t *testing.T) {
+	terminal := newTerminal(t, tuitest.ClientOptions{})
+	peer, err := tuitest.New(terminal.Session(), tuitest.ClientOptions{})
+	requireNoError(t, err)
+	names, err := tuitest.Sessions()
+	requireNoError(t, err)
+	if !slices.Contains(names, terminal.Session()) {
+		t.Fatalf("missing session in %v", names)
+	}
+	requireNoError(t, terminal.Close())
+	_, err = peer.Text(tuitest.TextOptions{})
+	requireKind(t, err, tuitest.NoSessionError)
+	runTerminal(t, terminal, tuitest.SpawnOptions{})
+	requireNoError(t, peer.GetByText("go-ready", tuitest.TextSelectorOptions{}).Expect(tuitest.LocatorExpectOptions{}))
+}
+
+func TestCloseInterruptsPendingWait(t *testing.T) {
+	t.Skip("Known upstream limitation accepted for this binding: named Close blocks behind pending waits; https://github.com/microsoft/tui-test/issues/207")
+	terminal := newTerminal(t, tuitest.ClientOptions{})
+	verifyWaitInterruption(t, terminal, terminal.Close)
+}
+
+func TestCloseAllInterruptsPendingWait(t *testing.T) {
+	terminal := newTerminal(t, tuitest.ClientOptions{})
+	verifyWaitInterruption(t, terminal, tuitest.CloseAll)
+}
+
+func verifyWaitInterruption(t *testing.T, terminal *tuitest.Client, closeSession func() error) {
+	t.Helper()
+	started := make(chan struct{})
+	waitResult := make(chan error, 1)
+	go func() {
+		close(started)
+		waitResult <- terminal.GetByText("never-visible", tuitest.TextSelectorOptions{}).Wait(tuitest.LocatorWaitOptions{Timeout: tuitest.Ptr(5 * time.Second)})
+	}()
+	<-started
+	select {
+	case err := <-waitResult:
+		t.Fatalf("wait returned before close: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	closeResult := make(chan error, 1)
+	go func() { closeResult <- closeSession() }()
+	select {
+	case err := <-closeResult:
+		requireNoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("close blocked behind the pending wait")
+	}
+	select {
+	case err := <-waitResult:
+		if err == nil {
+			t.Fatal("interrupted wait unexpectedly succeeded")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wait did not return after close")
+	}
+}
+
+func TestTimeoutOptionsAndTypedFailures(t *testing.T) {
+	_, err := tuitest.New("", tuitest.ClientOptions{Timeouts: tuitest.Timeouts{Text: tuitest.Ptr(-time.Nanosecond)}})
+	requireKind(t, err, tuitest.UsageError)
+	terminal := newTerminal(t, tuitest.ClientOptions{Timeouts: tuitest.Timeouts{Text: tuitest.Ptr(time.Duration(0))}, Artifacts: &tuitest.ArtifactOptions{Dir: t.TempDir(), OnFailure: tuitest.ArtifactSVG}})
+	err = terminal.GetByText("missing", tuitest.TextSelectorOptions{}).Expect(tuitest.LocatorExpectOptions{})
+	requireKind(t, err, tuitest.AssertionError)
+	var failure *tuitest.Error
+	if !errors.As(err, &failure) || failure.Terminal == nil || failure.Terminal.Screenshot == "" || !strings.Contains(failure.Message, "Terminal content:") {
+		t.Fatalf("missing diagnostic/artifact: %#v", failure)
+	}
+	_, err = terminal.Screenshot("", tuitest.ScreenshotOptions{Zoom: tuitest.Ptr(2.0)})
+	requireKind(t, err, tuitest.UsageError)
+	requireNoError(t, terminal.Close())
+	runTerminal(t, terminal, tuitest.SpawnOptions{Timeouts: tuitest.Timeouts{Text: tuitest.Ptr(1500 * time.Microsecond), Idle: tuitest.Ptr(time.Duration(0))}})
+	state, err := terminal.State()
+	requireNoError(t, err)
+	if state.Timeouts.Text != 2*time.Millisecond || state.Timeouts.Idle != 0 {
+		t.Fatalf("effective timeouts=%+v", state.Timeouts)
+	}
+}
+
+func TestRecordingAndCloseAll(t *testing.T) {
+	directory := t.TempDir()
+	terminal := newTerminal(t, tuitest.ClientOptions{Recording: &tuitest.AutomaticRecording{Mode: tuitest.RecordingAlways, Directory: directory}})
+	recording, err := tuitest.Recording(terminal.Session())
+	requireNoError(t, err)
+	if !strings.Contains(recording, `"version":2`) {
+		t.Fatal("missing automatic recording content")
+	}
+	requireNoError(t, terminal.StartRecording(filepath.Join(directory, "explicit.cast"), tuitest.RecordingOptions{Format: tuitest.Cast}))
+	requireNoError(t, terminal.Submit(tuitest.Ptr("recorded")))
+	requireNoError(t, terminal.GetByText("received:recorded", tuitest.TextSelectorOptions{}).Expect(tuitest.LocatorExpectOptions{}))
+	explicit, err := terminal.StopRecording()
+	requireNoError(t, err)
+	if _, statErr := os.Stat(explicit); statErr != nil {
+		t.Fatal(statErr)
+	}
+	requireNoError(t, tuitest.CloseAll())
+	retained, err := tuitest.Recording(terminal.Session())
+	requireNoError(t, err)
+	if !strings.Contains(retained, "recorded") {
+		t.Fatalf("retained recording omitted terminal output: %q", retained)
+	}
+}

--- a/bindings/go/internal/native/abi.go
+++ b/bindings/go/internal/native/abi.go
@@ -1,0 +1,231 @@
+package native
+
+import (
+	"structs"
+	"unsafe"
+)
+
+// These host-layout structures mirror the private C ABI in native.h.
+type abiString struct {
+	_    structs.HostLayout
+	data *uint8
+	len  uintptr
+}
+type abiOptionalI32 struct {
+	_       structs.HostLayout
+	present bool
+	value   int32
+}
+type abiOptionalU64 struct {
+	_       structs.HostLayout
+	present bool
+	value   uint64
+}
+type abiOpenResult struct {
+	_         structs.HostLayout
+	shellPID  abiOptionalU64
+	session   abiString
+	ready     bool
+	recording abiString
+}
+type abiCursor struct {
+	_ structs.HostLayout
+	x uint16
+	y uint16
+}
+type abiTimeouts struct {
+	_       structs.HostLayout
+	text    abiOptionalU64
+	idle    abiOptionalU64
+	command abiOptionalU64
+	exit    abiOptionalU64
+	ready   abiOptionalU64
+}
+type abiState struct {
+	_            structs.HostLayout
+	sessionShell abiString
+	cols         uint16
+	rows         uint16
+	cursor       abiCursor
+	title        abiString
+	cwd          abiString
+	lastCommand  abiString
+	lastExit     abiOptionalI32
+	exited       abiOptionalI32
+	ready        bool
+	bellCount    uint64
+	timeouts     abiTimeouts
+	text         abiString
+}
+type abiSize struct {
+	_    structs.HostLayout
+	cols uint16
+	rows uint16
+}
+type abiColor struct {
+	_     structs.HostLayout
+	kind  uint32
+	index uint8
+	red   uint8
+	green uint8
+	blue  uint8
+}
+type abiCell struct {
+	_              structs.HostLayout
+	x              uint16
+	y              uint16
+	character      abiString
+	fg             abiColor
+	bg             abiColor
+	bold           bool
+	dim            bool
+	italic         bool
+	inverse        bool
+	invisible      bool
+	strike         bool
+	blink          bool
+	underline      bool
+	underlineStyle abiString
+	underlineColor abiColor
+}
+type abiPosition struct {
+	_      structs.HostLayout
+	row    uint32
+	column uint16
+}
+type abiSpan struct {
+	_     structs.HostLayout
+	row   uint32
+	start uint16
+	end   uint16
+}
+type abiMatch struct {
+	_        structs.HostLayout
+	text     abiString
+	start    abiPosition
+	end      abiPosition
+	spans    *abiSpan
+	spansLen uintptr
+}
+type abiBellEvent struct {
+	_         structs.HostLayout
+	sequence  uint64
+	elapsedMS uint64
+}
+type abiResult struct {
+	_            structs.HostLayout
+	errorKind    uint32
+	errorMessage abiString
+	text         abiString
+	number       uint64
+	exitCode     abiOptionalI32
+	open         abiOpenResult
+	state        abiState
+	cursor       abiCursor
+	size         abiSize
+	cells        *abiCell
+	cellsLen     uintptr
+	matches      *abiMatch
+	matchesLen   uintptr
+	bells        *abiBellEvent
+	bellsLen     uintptr
+	strings      *abiString
+	stringsLen   uintptr
+	snapshot     uint32
+	privateData  unsafe.Pointer
+}
+type abiPair struct {
+	_     structs.HostLayout
+	key   abiString
+	value abiString
+}
+type abiOptionalBool struct {
+	_       structs.HostLayout
+	present bool
+	value   bool
+}
+type abiOpenOptions struct {
+	_                  structs.HostLayout
+	backend            abiString
+	shell              abiString
+	cols               abiOptionalU64
+	rows               abiOptionalU64
+	cwd                abiString
+	env                *abiPair
+	envLen             uintptr
+	waitReady          abiOptionalBool
+	restart            bool
+	scrollback         abiOptionalU64
+	colors             *abiPair
+	colorsLen          uintptr
+	timeouts           abiTimeouts
+	recordingMode      abiString
+	recordingDirectory abiString
+}
+type abiMouseOptions struct {
+	_      structs.HostLayout
+	button uint32
+	alt    bool
+	ctrl   bool
+	shift  bool
+}
+type abiWaitOptions struct {
+	_         structs.HostLayout
+	timeoutMS abiOptionalU64
+	regex     bool
+	not       bool
+}
+type abiAnchor struct {
+	_          structs.HostLayout
+	text       abiString
+	regex      bool
+	occurrence uint32
+	index      uintptr
+}
+type abiTextStyle struct {
+	_              structs.HostLayout
+	foreground     abiString
+	background     abiString
+	bold           abiOptionalBool
+	dim            abiOptionalBool
+	italic         abiOptionalBool
+	underlineStyle abiString
+	underlineColor abiString
+	inverse        abiOptionalBool
+	hidden         abiOptionalBool
+	strikethrough  abiOptionalBool
+	blink          abiOptionalBool
+}
+type abiLocatorStage struct {
+	_          structs.HostLayout
+	kind       uint32
+	text       abiString
+	regex      bool
+	full       bool
+	whitespace uint32
+	after      abiAnchor
+	before     abiAnchor
+	style      abiTextStyle
+	occurrence uint32
+	index      uintptr
+	direction  uint32
+}
+type abiQuery struct {
+	_      structs.HostLayout
+	stages *abiLocatorStage
+	len    uintptr
+}
+type abiOptionalF64 struct {
+	_       structs.HostLayout
+	present bool
+	value   float64
+}
+type abiRecordingOptions struct {
+	_             structs.HostLayout
+	path          abiString
+	format        abiString
+	fps           abiOptionalU64
+	speed         abiOptionalF64
+	idleTimeLimit abiOptionalF64
+	zoom          abiOptionalF64
+}

--- a/bindings/go/internal/native/functions.go
+++ b/bindings/go/internal/native/functions.go
@@ -1,0 +1,134 @@
+package native
+
+import "slices"
+
+type nativeFunctionTable struct {
+	AbiVersion       func() uint32
+	ResultFree       func(*abiResult)
+	Open             func(abiString, *abiOpenOptions) *abiResult
+	Run              func(abiString, *abiOpenOptions, abiString, *abiString, uintptr) *abiResult
+	Sessions         func() *abiResult
+	CloseAll         func() *abiResult
+	Recording        func(abiString) *abiResult
+	Close            func(abiString) *abiResult
+	State            func(abiString) *abiResult
+	GetCommand       func(abiString) *abiResult
+	GetOutput        func(abiString) *abiResult
+	GetExitCode      func(abiString) *abiResult
+	GetCwd           func(abiString) *abiResult
+	GetCursor        func(abiString) *abiResult
+	GetSize          func(abiString) *abiResult
+	GetTitle         func(abiString) *abiResult
+	GetClipboard     func(abiString) *abiResult
+	GetBellCount     func(abiString) *abiResult
+	GetBellEvents    func(abiString) *abiResult
+	StopRecording    func(abiString) *abiResult
+	Text             func(abiString, bool) *abiResult
+	PackedScreen     func(abiString, bool) *abiResult
+	Cells            func(abiString, uint16, uint16, uint16, uint16) *abiResult
+	Write            func(abiString, abiString) *abiResult
+	Submit           func(abiString, abiString) *abiResult
+	Signal           func(abiString, abiString) *abiResult
+	Key              func(abiString, *abiString, uintptr, uint32) *abiResult
+	Resize           func(abiString, uint16, uint16) *abiResult
+	MouseClick       func(abiString, abiOptionalU64, abiOptionalU64, abiString, abiMouseOptions, uint8) *abiResult
+	MouseMove        func(abiString, uint16, uint16) *abiResult
+	MouseDown        func(abiString, uint16, uint16, abiMouseOptions) *abiResult
+	MouseUp          func(abiString, uint16, uint16, abiMouseOptions) *abiResult
+	MouseDrag        func(abiString, uint16, uint16, uint16, uint16, abiMouseOptions) *abiResult
+	MouseScroll      func(abiString, abiString, uint16) *abiResult
+	WaitTitle        func(abiString, abiString, abiWaitOptions) *abiResult
+	ExpectTitle      func(abiString, abiString, abiWaitOptions) *abiResult
+	WaitClipboard    func(abiString, abiString, abiWaitOptions) *abiResult
+	WaitIdle         func(abiString, abiOptionalU64) *abiResult
+	WaitCommand      func(abiString, abiOptionalU64) *abiResult
+	WaitExit         func(abiString, abiOptionalU64) *abiResult
+	WaitReady        func(abiString, abiOptionalU64) *abiResult
+	WaitBell         func(abiString, abiOptionalU64) *abiResult
+	FindLocator      func(abiString, abiQuery) *abiResult
+	WaitLocator      func(abiString, abiQuery, abiWaitOptions) *abiResult
+	ClickLocator     func(abiString, abiQuery, abiMouseOptions, uint8, abiOptionalU64) *abiResult
+	HighlightLocator func(abiString, abiQuery, abiOptionalU64) *abiResult
+	ExpectExitCode   func(abiString, int32, abiOptionalU64) *abiResult
+	ExpectOutput     func(abiString, abiString, bool) *abiResult
+	ExpectBellCount  func(abiString, uint64, abiOptionalU64) *abiResult
+	Snapshot         func(abiString, abiString, bool, bool, bool, abiString) *abiResult
+	Screenshot       func(abiString, bool, abiString, abiOptionalF64) *abiResult
+	StartRecording   func(abiString, abiRecordingOptions) *abiResult
+}
+
+func nativeRegistrations(table *nativeFunctionTable) []nativeRegistration {
+	return slices.Concat(nativeLifecycleRegistrations(table), nativeInputRegistrations(table), nativeInspectionRegistrations(table), nativeWaitingRegistrations(table), nativeArtifactsRegistrations(table))
+}
+func nativeLifecycleRegistrations(table *nativeFunctionTable) []nativeRegistration {
+	return []nativeRegistration{
+		{symbol: "tui_abi_version", target: &table.AbiVersion},
+		{symbol: "tui_result_free", target: &table.ResultFree},
+		{symbol: "tui_open_ptr", target: &table.Open},
+		{symbol: "tui_run_ptr", target: &table.Run},
+		{symbol: "tui_sessions", target: &table.Sessions},
+		{symbol: "tui_close_all", target: &table.CloseAll},
+		{symbol: "tui_recording", target: &table.Recording},
+		{symbol: "tui_close", target: &table.Close},
+	}
+}
+func nativeInputRegistrations(table *nativeFunctionTable) []nativeRegistration {
+	return []nativeRegistration{
+		{symbol: "tui_write", target: &table.Write},
+		{symbol: "tui_submit", target: &table.Submit},
+		{symbol: "tui_signal", target: &table.Signal},
+		{symbol: "tui_key", target: &table.Key},
+		{symbol: "tui_resize", target: &table.Resize},
+		{symbol: "tui_mouse_click", target: &table.MouseClick},
+		{symbol: "tui_mouse_move", target: &table.MouseMove},
+		{symbol: "tui_mouse_down", target: &table.MouseDown},
+		{symbol: "tui_mouse_up", target: &table.MouseUp},
+		{symbol: "tui_mouse_drag", target: &table.MouseDrag},
+		{symbol: "tui_mouse_scroll", target: &table.MouseScroll},
+	}
+}
+func nativeInspectionRegistrations(table *nativeFunctionTable) []nativeRegistration {
+	return []nativeRegistration{
+		{symbol: "tui_state", target: &table.State},
+		{symbol: "tui_get_command", target: &table.GetCommand},
+		{symbol: "tui_get_output", target: &table.GetOutput},
+		{symbol: "tui_get_exit_code", target: &table.GetExitCode},
+		{symbol: "tui_get_cwd", target: &table.GetCwd},
+		{symbol: "tui_get_cursor", target: &table.GetCursor},
+		{symbol: "tui_get_size", target: &table.GetSize},
+		{symbol: "tui_get_title", target: &table.GetTitle},
+		{symbol: "tui_get_clipboard", target: &table.GetClipboard},
+		{symbol: "tui_get_bell_count", target: &table.GetBellCount},
+		{symbol: "tui_get_bell_events", target: &table.GetBellEvents},
+		{symbol: "tui_text", target: &table.Text},
+		{symbol: "tui_packed_screen", target: &table.PackedScreen},
+		{symbol: "tui_cells", target: &table.Cells},
+	}
+}
+func nativeWaitingRegistrations(table *nativeFunctionTable) []nativeRegistration {
+	return []nativeRegistration{
+		{symbol: "tui_wait_title", target: &table.WaitTitle},
+		{symbol: "tui_expect_title", target: &table.ExpectTitle},
+		{symbol: "tui_wait_clipboard", target: &table.WaitClipboard},
+		{symbol: "tui_wait_idle", target: &table.WaitIdle},
+		{symbol: "tui_wait_command", target: &table.WaitCommand},
+		{symbol: "tui_wait_exit", target: &table.WaitExit},
+		{symbol: "tui_wait_ready", target: &table.WaitReady},
+		{symbol: "tui_wait_bell", target: &table.WaitBell},
+		{symbol: "tui_find_locator", target: &table.FindLocator},
+		{symbol: "tui_wait_locator", target: &table.WaitLocator},
+		{symbol: "tui_click_locator", target: &table.ClickLocator},
+		{symbol: "tui_highlight_locator", target: &table.HighlightLocator},
+		{symbol: "tui_expect_exit_code", target: &table.ExpectExitCode},
+		{symbol: "tui_expect_output", target: &table.ExpectOutput},
+		{symbol: "tui_expect_bell_count", target: &table.ExpectBellCount},
+	}
+}
+func nativeArtifactsRegistrations(table *nativeFunctionTable) []nativeRegistration {
+	return []nativeRegistration{
+		{symbol: "tui_stop_recording", target: &table.StopRecording},
+		{symbol: "tui_snapshot", target: &table.Snapshot},
+		{symbol: "tui_screenshot", target: &table.Screenshot},
+		{symbol: "tui_start_recording", target: &table.StartRecording},
+	}
+}

--- a/bindings/go/internal/native/input.go
+++ b/bindings/go/internal/native/input.go
@@ -1,0 +1,187 @@
+package native
+
+import (
+	"time"
+)
+
+func nativeDuration(value *time.Duration) (abiOptionalU64, error) {
+	if value == nil {
+		return abiOptionalU64{}, nil
+	}
+	milliseconds, err := Milliseconds(*value)
+	if err != nil {
+		return abiOptionalU64{}, err
+	}
+	return nativeUint(&milliseconds), nil
+}
+
+func nativeTimeouts(timeouts Timeouts) (abiTimeouts, error) {
+	result := abiTimeouts{}
+	targets := []*abiOptionalU64{&result.text, &result.idle, &result.command, &result.exit, &result.ready}
+	for index, value := range []*time.Duration{timeouts.Text, timeouts.Idle, timeouts.Command, timeouts.Exit, timeouts.Ready} {
+		converted, err := nativeDuration(value)
+		if err != nil {
+			return result, err
+		}
+		*targets[index] = converted
+	}
+	return result, nil
+}
+
+func (memory *nativeMemory) colors(colors Colors) (*abiPair, uintptr) {
+	values := map[string]string{
+		"foreground": colors.Foreground, "background": colors.Background, "cursor": colors.Cursor,
+		"black": colors.Black, "red": colors.Red, "green": colors.Green, "yellow": colors.Yellow, "blue": colors.Blue, "magenta": colors.Magenta, "cyan": colors.Cyan, "white": colors.White,
+		"bright_black": colors.BrightBlack, "bright_red": colors.BrightRed, "bright_green": colors.BrightGreen, "bright_yellow": colors.BrightYellow, "bright_blue": colors.BrightBlue, "bright_magenta": colors.BrightMagenta, "bright_cyan": colors.BrightCyan, "bright_white": colors.BrightWhite,
+	}
+	for key, value := range values {
+		if value == "" {
+			delete(values, key)
+		}
+	}
+	return memory.pairs(values)
+}
+
+func (memory *nativeMemory) openOptions(options OpenOptions, recording *AutomaticRecording) (abiOpenOptions, error) {
+	timeouts, err := nativeTimeouts(options.Timeouts)
+	if err != nil {
+		return abiOpenOptions{}, err
+	}
+	result := abiOpenOptions{backend: memory.nonemptyText(string(options.Backend)), shell: memory.nonemptyText(string(options.Shell)), cols: nativeUint(options.Cols), rows: nativeUint(options.Rows), cwd: memory.nonemptyText(options.Cwd), waitReady: nativeBool(options.WaitReady), timeouts: timeouts}
+	if options.Restart != nil {
+		result.restart = *options.Restart
+	}
+	result.env, result.envLen = memory.pairs(options.Env)
+	if options.Profile != nil {
+		result.scrollback = nativeUint(options.Profile.Scrollback)
+		result.colors, result.colorsLen = memory.colors(options.Profile.Colors)
+	}
+	if recording != nil {
+		result.recordingMode = memory.nonemptyText(string(recording.Mode))
+		result.recordingDirectory = memory.nonemptyText(recording.Directory)
+	}
+	return result, nil
+}
+
+func nativeBool(value *bool) abiOptionalBool {
+	if value == nil {
+		return abiOptionalBool{}
+	}
+	return abiOptionalBool{present: true, value: *value}
+}
+
+func nativeUint[Number ~uint16 | ~uint32 | ~uint64](value *Number) abiOptionalU64 {
+	if value == nil {
+		return abiOptionalU64{}
+	}
+	return abiOptionalU64{present: true, value: uint64(*value)}
+}
+
+func nativeFloat(value *float64) abiOptionalF64 {
+	if value == nil {
+		return abiOptionalF64{}
+	}
+	return abiOptionalF64{present: true, value: float64(*value)}
+}
+
+func (memory *nativeMemory) style(style TextStyle) abiTextStyle {
+	result := abiTextStyle{foreground: memory.optionalText(style.Foreground), background: memory.optionalText(style.Background), bold: nativeBool(style.Bold), dim: nativeBool(style.Dim), italic: nativeBool(style.Italic), underlineColor: memory.optionalText(style.UnderlineColor), inverse: nativeBool(style.Inverse), hidden: nativeBool(style.Hidden), strikethrough: nativeBool(style.Strikethrough), blink: nativeBool(style.Blink)}
+	if style.UnderlineStyle != nil {
+		result.underlineStyle = memory.text(string(*style.UnderlineStyle))
+	}
+	return result
+}
+
+func nativeDirection(direction Direction) uint32 {
+	switch direction {
+	case "", Within:
+		return 0
+	case After:
+		return 1
+	case Before:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func nativeWhitespace(whitespace Whitespace) uint32 {
+	switch whitespace {
+	case "", Exact:
+		return 0
+	case Normalize:
+		return 1
+	default:
+		return 2
+	}
+}
+
+func nativeOccurrence(occurrence string) uint32 {
+	switch occurrence {
+	case "any":
+		return 0
+	case "unique":
+		return 1
+	case "first":
+		return 2
+	case "last":
+		return 3
+	case "nth":
+		return 4
+	default:
+		return 5
+	}
+}
+
+func (memory *nativeMemory) stage(stage LocatorStage) abiLocatorStage {
+	converted := abiLocatorStage{style: memory.style(stage.Style), index: uintptr(stage.Nth), occurrence: nativeOccurrence(stage.Occurrence)}
+	if stage.Kind == "style" {
+		converted.kind = 1
+		converted.full = stage.StyleOptions.Full
+		converted.direction = nativeDirection(stage.StyleOptions.Direction)
+		return converted
+	}
+	converted.text = memory.text(stage.Text)
+	converted.regex = stage.TextOptions.Regex
+	converted.full = stage.TextOptions.Full
+	converted.whitespace = nativeWhitespace(stage.TextOptions.Whitespace)
+	converted.direction = nativeDirection(stage.TextOptions.Direction)
+	return converted
+}
+
+func (memory *nativeMemory) query(stages []LocatorStage) (abiQuery, error) {
+	if len(stages) == 0 {
+		return abiQuery{}, &Error{Kind: UsageError, Message: "locator requires at least one stage"}
+	}
+	entries := make([]abiLocatorStage, len(stages))
+	pointer := &entries[0]
+	memory.pinner.Pin(pointer)
+	for index, stage := range stages {
+		entries[index] = memory.stage(stage)
+	}
+	return abiQuery{stages: pointer, len: uintptr(len(stages))}, nil
+}
+
+func nativeMouse(options MouseButtonOptions) (abiMouseOptions, error) {
+	result := abiMouseOptions{alt: options.Alt, ctrl: options.Ctrl, shift: options.Shift}
+	switch options.Button {
+	case "", Left:
+	case Middle:
+		result.button = 1
+	case Right:
+		result.button = 2
+	default:
+		return result, &Error{Kind: UsageError, Message: "unknown mouse button"}
+	}
+	return result, nil
+}
+
+func nativeClicks(clicks *uint32) (uint8, error) {
+	if clicks == nil {
+		return 1, nil
+	}
+	if *clicks > 255 {
+		return 0, &Error{Kind: UsageError, Message: "clicks must be between 0 and 255"}
+	}
+	return uint8(*clicks), nil
+}

--- a/bindings/go/internal/native/loader.go
+++ b/bindings/go/internal/native/loader.go
@@ -1,0 +1,63 @@
+package native
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/ebitengine/purego"
+)
+
+type nativeRegistration struct {
+	symbol string
+	target any
+}
+
+// Registered functions and the loaded library stay live for the process lifetime.
+var nativeFunctions nativeFunctionTable
+var loadNativeEngine = sync.OnceValue(initializeNativeEngine)
+
+func initializeNativeEngine() error {
+	path := os.Getenv("TUI_TEST_GO_NATIVE_LIBRARY")
+	if path == "" {
+		return errors.New("TUI_TEST_GO_NATIVE_LIBRARY must name the native engine library")
+	}
+	table, err := loadNativeFunctions(path)
+	if err != nil {
+		return fmt.Errorf("load native engine from TUI_TEST_GO_NATIVE_LIBRARY: %w", err)
+	}
+	nativeFunctions = table
+	return nil
+}
+
+func loadNativeFunctions(path string) (nativeFunctionTable, error) {
+	table := nativeFunctionTable{}
+	library, err := openNativeLibrary(path)
+	if err != nil {
+		return table, err
+	}
+	for _, registration := range nativeRegistrations(&table) {
+		if registerErr := registerNativeFunction(library, registration); registerErr != nil {
+			return nativeFunctionTable{}, errors.Join(registerErr, library.close())
+		}
+	}
+	if version := table.AbiVersion(); version != 1 {
+		return nativeFunctionTable{}, errors.Join(fmt.Errorf("native ABI version %d is incompatible with required version 1", version), library.close())
+	}
+	return table, nil
+}
+
+func registerNativeFunction(library *nativeLibraryHandle, registration nativeRegistration) (err error) {
+	address, err := library.symbol(registration.symbol)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if failure := recover(); failure != nil {
+			err = fmt.Errorf("register native function %s: %v", registration.symbol, failure)
+		}
+	}()
+	purego.RegisterFunc(registration.target, address)
+	return nil
+}

--- a/bindings/go/internal/native/loader_test.go
+++ b/bindings/go/internal/native/loader_test.go
@@ -1,0 +1,24 @@
+package native
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInitializeNativeEngineRequiresConfiguredLibrary(t *testing.T) {
+	t.Setenv("TUI_TEST_GO_NATIVE_LIBRARY", "")
+
+	err := initializeNativeEngine()
+	if err == nil || !strings.Contains(err.Error(), "TUI_TEST_GO_NATIVE_LIBRARY must name") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInitializeNativeEngineReportsConfiguredLibraryFailure(t *testing.T) {
+	t.Setenv("TUI_TEST_GO_NATIVE_LIBRARY", t.TempDir())
+
+	err := initializeNativeEngine()
+	if err == nil || !strings.Contains(err.Error(), "load native engine from TUI_TEST_GO_NATIVE_LIBRARY") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/bindings/go/internal/native/loader_unix.go
+++ b/bindings/go/internal/native/loader_unix.go
@@ -1,0 +1,32 @@
+//go:build linux || darwin || freebsd || netbsd
+
+package native
+
+import (
+	"fmt"
+
+	"github.com/ebitengine/purego"
+)
+
+type nativeLibraryHandle struct{ library uintptr }
+
+func openNativeLibrary(path string) (*nativeLibraryHandle, error) {
+	library, err := purego.Dlopen(path, purego.RTLD_NOW|purego.RTLD_LOCAL)
+	if err != nil {
+		return nil, fmt.Errorf("load native library %q: %w", path, err)
+	}
+	return &nativeLibraryHandle{library: library}, nil
+}
+func (handle *nativeLibraryHandle) symbol(name string) (uintptr, error) {
+	address, err := purego.Dlsym(handle.library, name)
+	if err != nil {
+		return 0, fmt.Errorf("find native symbol %q: %w", name, err)
+	}
+	return address, nil
+}
+func (handle *nativeLibraryHandle) close() error {
+	if err := purego.Dlclose(handle.library); err != nil {
+		return fmt.Errorf("release native library: %w", err)
+	}
+	return nil
+}

--- a/bindings/go/internal/native/loader_windows.go
+++ b/bindings/go/internal/native/loader_windows.go
@@ -1,0 +1,29 @@
+package native
+
+import (
+	"fmt"
+	"syscall"
+)
+
+type nativeLibraryHandle struct{ library *syscall.DLL }
+
+func openNativeLibrary(path string) (*nativeLibraryHandle, error) {
+	library, err := syscall.LoadDLL(path)
+	if err != nil {
+		return nil, fmt.Errorf("load native library %q: %w", path, err)
+	}
+	return &nativeLibraryHandle{library: library}, nil
+}
+func (handle *nativeLibraryHandle) symbol(name string) (uintptr, error) {
+	procedure, err := handle.library.FindProc(name)
+	if err != nil {
+		return 0, fmt.Errorf("find native symbol %q: %w", name, err)
+	}
+	return procedure.Addr(), nil
+}
+func (handle *nativeLibraryHandle) close() error {
+	if err := handle.library.Release(); err != nil {
+		return fmt.Errorf("release native library: %w", err)
+	}
+	return nil
+}

--- a/bindings/go/internal/native/memory.go
+++ b/bindings/go/internal/native/memory.go
@@ -1,0 +1,63 @@
+package native
+
+import (
+	"runtime"
+)
+
+// nativeMemory pins input buffers until the synchronous Rust call returns.
+// Rust copies these buffers and does not retain Go pointers.
+type nativeMemory struct{ pinner runtime.Pinner }
+
+func (memory *nativeMemory) release() {
+	memory.pinner.Unpin()
+}
+
+func (memory *nativeMemory) text(value string) abiString {
+	buffer := make([]byte, len(value)+1)
+	copy(buffer, value)
+	pointer := &buffer[0]
+	memory.pinner.Pin(pointer)
+	return abiString{data: pointer, len: uintptr(len(value))}
+}
+
+func (memory *nativeMemory) optionalText(value *string) abiString {
+	if value == nil {
+		return abiString{}
+	}
+	return memory.text(*value)
+}
+
+func (memory *nativeMemory) nonemptyText(value string) abiString {
+	if value == "" {
+		return abiString{}
+	}
+	return memory.text(value)
+}
+
+func (memory *nativeMemory) pairs(values map[string]string) (*abiPair, uintptr) {
+	if len(values) == 0 {
+		return nil, 0
+	}
+	entries := make([]abiPair, len(values))
+	pointer := &entries[0]
+	memory.pinner.Pin(pointer)
+	index := 0
+	for key, value := range values {
+		entries[index] = abiPair{key: memory.text(key), value: memory.text(value)}
+		index++
+	}
+	return pointer, uintptr(len(values))
+}
+
+func (memory *nativeMemory) strings(values []string) (*abiString, uintptr) {
+	if len(values) == 0 {
+		return nil, 0
+	}
+	entries := make([]abiString, len(values))
+	pointer := &entries[0]
+	memory.pinner.Pin(pointer)
+	for index, value := range values {
+		entries[index] = memory.text(value)
+	}
+	return pointer, uintptr(len(values))
+}

--- a/bindings/go/internal/native/models.go
+++ b/bindings/go/internal/native/models.go
@@ -1,0 +1,282 @@
+package native
+
+import "time"
+
+type Backend string
+
+const (
+	Alacritty Backend = "alacritty"
+	Ghostty   Backend = "ghostty"
+	Rio       Backend = "rio"
+	XtermJS   Backend = "xtermjs"
+)
+
+type Shell string
+
+const (
+	Bash       Shell = "bash"
+	PowerShell Shell = "powershell"
+	Pwsh       Shell = "pwsh"
+	Cmd        Shell = "cmd"
+	Fish       Shell = "fish"
+	Zsh        Shell = "zsh"
+	Xonsh      Shell = "xonsh"
+	Elvish     Shell = "elvish"
+	Nushell    Shell = "nushell"
+)
+
+type UnderlineStyle string
+
+const (
+	UnderlineNone   UnderlineStyle = "none"
+	UnderlineSingle UnderlineStyle = "single"
+	UnderlineDouble UnderlineStyle = "double"
+	UnderlineCurly  UnderlineStyle = "curly"
+	UnderlineDotted UnderlineStyle = "dotted"
+	UnderlineDashed UnderlineStyle = "dashed"
+)
+
+type RecordingMode string
+
+const (
+	RecordingDisabled  RecordingMode = "disabled"
+	RecordingOnFailure RecordingMode = "on-failure"
+	RecordingAlways    RecordingMode = "always"
+)
+
+type RecordingFormat string
+
+const (
+	APNG RecordingFormat = "apng"
+	GIF  RecordingFormat = "gif"
+	MP4  RecordingFormat = "mp4"
+	Cast RecordingFormat = "cast"
+)
+
+type MouseButton string
+
+const (
+	Left   MouseButton = "left"
+	Middle MouseButton = "middle"
+	Right  MouseButton = "right"
+)
+
+type Direction string
+
+const (
+	Within Direction = "within"
+	After  Direction = "after"
+	Before Direction = "before"
+)
+
+type Whitespace string
+
+const (
+	Exact     Whitespace = "exact"
+	Normalize Whitespace = "normalize"
+)
+
+type ScrollDirection string
+
+const (
+	Up   ScrollDirection = "up"
+	Down ScrollDirection = "down"
+)
+
+type Timeouts struct{ Text, Idle, Command, Exit, Ready *time.Duration }
+
+type EffectiveTimeouts struct{ Text, Idle, Command, Exit, Ready time.Duration }
+
+type Colors struct {
+	Foreground, Background, Cursor                                                                        string
+	Black, Red, Green, Yellow, Blue, Magenta, Cyan, White                                                 string
+	BrightBlack, BrightRed, BrightGreen, BrightYellow, BrightBlue, BrightMagenta, BrightCyan, BrightWhite string
+}
+
+type Profile struct {
+	Scrollback *uint32
+	Colors     Colors
+}
+
+type AutomaticRecording struct {
+	Mode      RecordingMode
+	Directory string
+}
+
+type SpawnOptions struct {
+	Backend            Backend
+	Cols, Rows         *uint16
+	Cwd                string
+	Env                map[string]string
+	WaitReady, Restart *bool
+	Profile            *Profile
+	Timeouts           Timeouts
+}
+
+type OpenOptions struct {
+	SpawnOptions
+	Shell Shell
+}
+
+type TitleOptions struct {
+	Regex, Not bool
+	Timeout    *time.Duration
+}
+
+type ClipboardWaitOptions struct {
+	Text    *string
+	Regex   bool
+	Timeout *time.Duration
+}
+
+type ScreenshotOptions struct {
+	Full bool
+	Zoom *float64
+}
+
+type RecordingOptions struct {
+	Format                     RecordingFormat
+	FPS                        *uint32
+	Speed, IdleTimeLimit, Zoom *float64
+}
+
+type SnapshotOptions struct {
+	Update, IncludeColors, IncludeTitle bool
+	Cwd                                 string
+}
+
+type SnapshotResult string
+
+const (
+	SnapshotPassed  SnapshotResult = "passed"
+	SnapshotWritten SnapshotResult = "written"
+	SnapshotUpdated SnapshotResult = "updated"
+)
+
+type TextStyle struct {
+	Foreground, Background                *string
+	Bold, Dim, Italic                     *bool
+	UnderlineStyle                        *UnderlineStyle
+	UnderlineColor                        *string
+	Inverse, Hidden, Strikethrough, Blink *bool
+}
+
+type LocatorExpectOptions struct {
+	Not     bool
+	Timeout *time.Duration
+}
+
+type MouseButtonOptions struct {
+	Button           MouseButton
+	Alt, Ctrl, Shift bool
+}
+
+type MouseClickOptions struct {
+	MouseButtonOptions
+	X, Y   *uint16
+	OnText *string
+	Clicks *uint32
+}
+
+type LocatorClickOptions struct {
+	MouseButtonOptions
+	Clicks  *uint32
+	Timeout *time.Duration
+}
+
+type Cursor struct{ X, Y uint16 }
+
+type Size struct{ Cols, Rows uint16 }
+
+type Color string
+
+type Cell struct {
+	X, Y                                                            uint16
+	Char                                                            string
+	FG, BG                                                          Color
+	Bold, Dim, Italic, Inverse, Invisible, Strike, Blink, Underline bool
+	UnderlineStyle                                                  UnderlineStyle
+	UnderlineColor                                                  Color
+}
+
+type BellEvent struct {
+	Sequence uint64
+	Elapsed  time.Duration
+}
+
+type TextPosition struct{ Row, Column uint32 }
+
+type TextSpan struct{ Row, Start, End uint32 }
+
+type TextMatch struct {
+	Text       string
+	Start, End TextPosition
+	Spans      []TextSpan
+}
+
+type OpenResult struct {
+	ShellPID  *uint32
+	Session   string
+	Ready     bool
+	Recording string
+}
+
+type State struct {
+	SessionShell            *string
+	Cols, Rows              uint16
+	Cursor                  Cursor
+	Title, Cwd, LastCommand *string
+	LastExit, Exited        *int32
+	Ready                   bool
+	BellCount               uint64
+	Timeouts                EffectiveTimeouts
+	Text                    string
+}
+
+type ErrorKind string
+
+const (
+	AssertionError ErrorKind = "assertion"
+	UsageError     ErrorKind = "usage"
+	NoSessionError ErrorKind = "no-session"
+	InternalError  ErrorKind = "internal"
+)
+
+type Error struct {
+	Kind    ErrorKind
+	Message string
+}
+
+func (failure *Error) Error() string          { return failure.Message }
+func pointerTo[Value any](value Value) *Value { return &value }
+
+type LocatorStage struct {
+	Kind         string
+	Text         string
+	TextOptions  TextSelectorOptions
+	Style        TextStyle
+	StyleOptions StyleSelectorOptions
+	Occurrence   string
+	Nth          uint32
+}
+
+type TextSelectorOptions struct {
+	Regex, Full bool
+	Whitespace  Whitespace
+	Direction   Direction
+}
+type StyleSelectorOptions struct {
+	Full      bool
+	Direction Direction
+}
+
+func Milliseconds(timeout time.Duration) (uint64, error) {
+	if timeout < 0 {
+		return 0, &Error{Kind: UsageError, Message: "timeout must not be negative"}
+	}
+	milliseconds := uint64(timeout / time.Millisecond)
+	if timeout%time.Millisecond != 0 {
+		milliseconds++
+	}
+	return milliseconds, nil
+}

--- a/bindings/go/internal/native/results.go
+++ b/bindings/go/internal/native/results.go
@@ -1,0 +1,123 @@
+package native
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+	"unsafe"
+)
+
+func nativeText(value abiString) string {
+	if value.data == nil {
+		return ""
+	}
+	return string(unsafe.Slice(value.data, value.len)) //nolint:gosec // G103: Copies Rust-owned bytes into a Go string before the owning result is freed.
+}
+
+func nativeOptionalText(value abiString) *string {
+	if value.data == nil {
+		return nil
+	}
+	return pointerTo(nativeText(value))
+}
+
+func readOpenResult(result *abiResult) (OpenResult, error) {
+	if err := nativeError(result); err != nil {
+		return OpenResult{}, err
+	}
+	opened := result.open
+	converted := OpenResult{Session: nativeText(opened.session), Ready: opened.ready, Recording: nativeText(opened.recording)}
+	if opened.shellPID.present {
+		if opened.shellPID.value > math.MaxUint32 {
+			return OpenResult{}, &Error{Kind: InternalError, Message: "native process identifier exceeds uint32"}
+		}
+		converted.ShellPID = pointerTo(uint32(opened.shellPID.value))
+	}
+	return converted, nil
+}
+
+func nativeInt(value abiOptionalI32) *int32 {
+	if !value.present {
+		return nil
+	}
+	return pointerTo(value.value)
+}
+
+func nativeError(result *abiResult) error {
+	if result == nil {
+		return &Error{Kind: InternalError, Message: "native engine returned no result"}
+	}
+	if result.errorKind == 0 {
+		return nil
+	}
+	kind := InternalError
+	switch result.errorKind {
+	case 1:
+		kind = AssertionError
+	case 2:
+		kind = UsageError
+	case 3:
+		kind = NoSessionError
+	}
+	return &Error{Kind: kind, Message: nativeText(result.errorMessage)}
+}
+
+func nativeColor(value abiColor) Color {
+	switch value.kind {
+	case 1:
+		return Color(strconv.Itoa(int(value.index)))
+	case 2:
+		return Color(fmt.Sprintf("#%02x%02x%02x", value.red, value.green, value.blue))
+	default:
+		return "default"
+	}
+}
+
+func nativeCells(result *abiResult) []Cell {
+	cells := make([]Cell, int(result.cellsLen))
+	for index, cell := range unsafe.Slice(result.cells, int(result.cellsLen)) { //nolint:gosec // G103: Rust supplies the cell buffer and length; all fields are copied before ResultFree.
+		cells[index] = Cell{X: cell.x, Y: cell.y, Char: nativeText(cell.character), FG: nativeColor(cell.fg), BG: nativeColor(cell.bg), Bold: cell.bold, Dim: cell.dim, Italic: cell.italic, Inverse: cell.inverse, Invisible: cell.invisible, Strike: cell.strike, Blink: cell.blink, Underline: cell.underline, UnderlineStyle: UnderlineStyle(nativeText(cell.underlineStyle)), UnderlineColor: nativeColor(cell.underlineColor)}
+	}
+	return cells
+}
+
+func nativeMatches(result *abiResult) []TextMatch {
+	matches := make([]TextMatch, int(result.matchesLen))
+	for index, match := range unsafe.Slice(result.matches, int(result.matchesLen)) { //nolint:gosec // G103: Rust supplies the match buffer and length; nested data is copied before ResultFree.
+		spans := make([]TextSpan, int(match.spansLen))
+		for spanIndex, span := range unsafe.Slice(match.spans, int(match.spansLen)) { //nolint:gosec // G103: The owning Rust result keeps spans alive until this copy finishes, before ResultFree.
+			spans[spanIndex] = TextSpan{Row: span.row, Start: uint32(span.start), End: uint32(span.end)}
+		}
+		matches[index] = TextMatch{Text: nativeText(match.text), Start: TextPosition{Row: match.start.row, Column: uint32(match.start.column)}, End: TextPosition{Row: match.end.row, Column: uint32(match.end.column)}, Spans: spans}
+	}
+	return matches
+}
+
+func nativeState(value abiState) State {
+	return State{SessionShell: nativeOptionalText(value.sessionShell), Cols: value.cols, Rows: value.rows, Cursor: Cursor{X: value.cursor.x, Y: value.cursor.y}, Title: nativeOptionalText(value.title), Cwd: nativeOptionalText(value.cwd), LastCommand: nativeOptionalText(value.lastCommand), LastExit: nativeInt(value.lastExit), Exited: nativeInt(value.exited), Ready: value.ready, BellCount: value.bellCount, Text: nativeText(value.text), Timeouts: EffectiveTimeouts{Text: nativeMilliseconds(value.timeouts.text.value), Idle: nativeMilliseconds(value.timeouts.idle.value), Command: nativeMilliseconds(value.timeouts.command.value), Exit: nativeMilliseconds(value.timeouts.exit.value), Ready: nativeMilliseconds(value.timeouts.ready.value)}}
+}
+
+// Millisecond precision can round a maximum Go duration beyond its range.
+func nativeMilliseconds(value uint64) time.Duration {
+	if value > uint64(math.MaxInt64/int64(time.Millisecond)) {
+		return time.Duration(math.MaxInt64)
+	}
+	return time.Duration(value) * time.Millisecond
+}
+
+func nativeSessionNames(result *abiResult) []string {
+	sessions := make([]string, int(result.stringsLen))
+	for index, value := range unsafe.Slice(result.strings, int(result.stringsLen)) { //nolint:gosec // G103: Rust supplies the session buffer and length; each string is copied before deferred ResultFree.
+		sessions[index] = nativeText(value)
+	}
+	return sessions
+}
+
+func nativeBellEvents(result *abiResult) []BellEvent {
+	events := make([]BellEvent, int(result.bellsLen))
+	for index, value := range unsafe.Slice(result.bells, int(result.bellsLen)) { //nolint:gosec // G103: Rust supplies the event buffer and length; values are copied before deferred ResultFree.
+		events[index] = BellEvent{Sequence: value.sequence, Elapsed: nativeMilliseconds(value.elapsedMS)}
+	}
+	return events
+}

--- a/bindings/go/internal/native/session.go
+++ b/bindings/go/internal/native/session.go
@@ -1,0 +1,537 @@
+package native
+
+import (
+	"fmt"
+	"time"
+)
+
+type Session struct {
+	name      string
+	recording *AutomaticRecording
+}
+
+func NewSession(name string, recording *AutomaticRecording) (*Session, error) {
+	if err := checkNativeVersion(); err != nil {
+		return nil, err
+	}
+	return &Session{name: name, recording: recording}, nil
+}
+
+func checkNativeVersion() error {
+	if err := loadNativeEngine(); err != nil {
+		return &Error{Kind: InternalError, Message: err.Error()}
+	}
+	if version := nativeFunctions.AbiVersion(); version != 1 {
+		return &Error{Kind: InternalError, Message: fmt.Sprintf("native ABI version %d is incompatible with required version 1", version)}
+	}
+	return nil
+}
+
+func Sessions() ([]string, error) {
+	if err := checkNativeVersion(); err != nil {
+		return nil, err
+	}
+	result := nativeFunctions.Sessions()
+	defer nativeFunctions.ResultFree(result)
+	if err := nativeError(result); err != nil {
+		return nil, err
+	}
+	return nativeSessionNames(result), nil
+}
+
+func CloseAll() error {
+	if err := checkNativeVersion(); err != nil {
+		return err
+	}
+	result := nativeFunctions.CloseAll()
+	defer nativeFunctions.ResultFree(result)
+	return nativeError(result)
+}
+
+func Recording(session string) (string, error) {
+	if err := checkNativeVersion(); err != nil {
+		return "", err
+	}
+	memory := nativeMemory{}
+	defer memory.release()
+	result := nativeFunctions.Recording(memory.text(session))
+	defer nativeFunctions.ResultFree(result)
+	if err := nativeError(result); err != nil {
+		return "", err
+	}
+	return nativeText(result.text), nil
+}
+
+func (runtime *Session) Open(options OpenOptions) (OpenResult, error) {
+	memory := nativeMemory{}
+	defer memory.release()
+	converted, err := memory.openOptions(options, runtime.recording)
+	if err != nil {
+		return OpenResult{}, err
+	}
+	memory.pinner.Pin(&converted)
+	result := nativeFunctions.Open(memory.text(runtime.name), &converted)
+	defer nativeFunctions.ResultFree(result)
+	return readOpenResult(result)
+}
+
+func (runtime *Session) Run(program string, args []string, options SpawnOptions) (OpenResult, error) {
+	memory := nativeMemory{}
+	defer memory.release()
+	converted, err := memory.openOptions(OpenOptions{SpawnOptions: options}, runtime.recording)
+	if err != nil {
+		return OpenResult{}, err
+	}
+	arguments, length := memory.strings(args)
+	memory.pinner.Pin(&converted)
+	result := nativeFunctions.Run(memory.text(runtime.name), &converted, memory.text(program), arguments, length)
+	defer nativeFunctions.ResultFree(result)
+	return readOpenResult(result)
+}
+
+func (runtime *Session) State() (State, error) {
+	memory := nativeMemory{}
+	defer memory.release()
+	result := nativeFunctions.State(memory.text(runtime.name))
+	defer nativeFunctions.ResultFree(result)
+	if err := nativeError(result); err != nil {
+		return State{}, err
+	}
+	return nativeState(result.state), nil
+}
+
+func (runtime *Session) Text(full bool) (string, error) {
+	memory := nativeMemory{}
+	defer memory.release()
+	result := nativeFunctions.Text(memory.text(runtime.name), full)
+	defer nativeFunctions.ResultFree(result)
+	if err := nativeError(result); err != nil {
+		return "", err
+	}
+	return nativeText(result.text), nil
+}
+
+func (runtime *Session) Cells(column, row, width, height uint16) ([]Cell, error) {
+	memory := nativeMemory{}
+	defer memory.release()
+	result := nativeFunctions.Cells(memory.text(runtime.name), column, row, width, height)
+	defer nativeFunctions.ResultFree(result)
+	if err := nativeError(result); err != nil {
+		return nil, err
+	}
+	return nativeCells(result), nil
+}
+
+func (runtime *Session) Resize(cols, rows uint16) error {
+	memory := nativeMemory{}
+	defer memory.release()
+	result := nativeFunctions.Resize(memory.text(runtime.name), cols, rows)
+	defer nativeFunctions.ResultFree(result)
+	return nativeError(result)
+}
+
+func (runtime *Session) Submit(text *string) error {
+	memory := nativeMemory{}
+	defer memory.release()
+	result := nativeFunctions.Submit(memory.text(runtime.name), memory.optionalText(text))
+	defer nativeFunctions.ResultFree(result)
+	return nativeError(result)
+}
+
+func (runtime *Session) Key(keys []string, action uint32) error {
+	memory := nativeMemory{}
+	defer memory.release()
+	values, length := memory.strings(keys)
+	result := nativeFunctions.Key(memory.text(runtime.name), values, length, action)
+	defer nativeFunctions.ResultFree(result)
+	return nativeError(result)
+}
+
+func (runtime *Session) GetCursor() (Cursor, error) {
+	memory := nativeMemory{}
+	defer memory.release()
+	result := nativeFunctions.GetCursor(memory.text(runtime.name))
+	defer nativeFunctions.ResultFree(result)
+	if err := nativeError(result); err != nil {
+		return Cursor{}, err
+	}
+	return Cursor{X: result.cursor.x, Y: result.cursor.y}, nil
+}
+
+func (runtime *Session) GetSize() (Size, error) {
+	memory := nativeMemory{}
+	defer memory.release()
+	result := nativeFunctions.GetSize(memory.text(runtime.name))
+	defer nativeFunctions.ResultFree(result)
+	if err := nativeError(result); err != nil {
+		return Size{}, err
+	}
+	return Size{Cols: result.size.cols, Rows: result.size.rows}, nil
+}
+
+func (runtime *Session) GetExitCode() (*int32, error) {
+	memory := nativeMemory{}
+	defer memory.release()
+	result := nativeFunctions.GetExitCode(memory.text(runtime.name))
+	defer nativeFunctions.ResultFree(result)
+	if err := nativeError(result); err != nil {
+		return nil, err
+	}
+	return nativeInt(result.exitCode), nil
+}
+
+func (runtime *Session) GetBellCount() (uint64, error) {
+	memory := nativeMemory{}
+	defer memory.release()
+	result := nativeFunctions.GetBellCount(memory.text(runtime.name))
+	defer nativeFunctions.ResultFree(result)
+	if err := nativeError(result); err != nil {
+		return 0, err
+	}
+	return result.number, nil
+}
+
+func (runtime *Session) GetBellEvents() ([]BellEvent, error) {
+	memory := nativeMemory{}
+	defer memory.release()
+	result := nativeFunctions.GetBellEvents(memory.text(runtime.name))
+	defer nativeFunctions.ResultFree(result)
+	if err := nativeError(result); err != nil {
+		return nil, err
+	}
+	return nativeBellEvents(result), nil
+}
+
+func (runtime *Session) read(call func(abiString, *nativeMemory) *abiResult, read func(*abiResult)) error {
+	memory := nativeMemory{}
+	defer memory.release()
+	result := call(memory.text(runtime.name), &memory)
+	defer nativeFunctions.ResultFree(result)
+	if err := nativeError(result); err != nil {
+		return err
+	}
+	read(result)
+	return nil
+}
+
+func (runtime *Session) unit(call func(abiString, *nativeMemory) *abiResult) error {
+	return runtime.read(call, func(*abiResult) {})
+}
+
+func (runtime *Session) optionalTextResult(call func(abiString, *nativeMemory) *abiResult) (*string, error) {
+	var text *string
+	err := runtime.read(call, func(result *abiResult) { text = nativeOptionalText(result.text) })
+	return text, err
+}
+
+func (runtime *Session) textResult(call func(abiString, *nativeMemory) *abiResult) (string, error) {
+	var text string
+	err := runtime.read(call, func(result *abiResult) { text = nativeText(result.text) })
+	return text, err
+}
+
+func (runtime *Session) Close() error {
+	return runtime.unit(func(session abiString, _ *nativeMemory) *abiResult { return nativeFunctions.Close(session) })
+}
+
+func (runtime *Session) Write(text string) error {
+	return runtime.unit(func(session abiString, memory *nativeMemory) *abiResult {
+		return nativeFunctions.Write(session, memory.text(text))
+	})
+}
+
+func (runtime *Session) TypeText(text string) error { return runtime.Write(text) }
+
+func (runtime *Session) Signal(text string) error {
+	return runtime.unit(func(session abiString, memory *nativeMemory) *abiResult {
+		return nativeFunctions.Signal(session, memory.text(text))
+	})
+}
+
+func (runtime *Session) GetCommand() (*string, error) {
+	return runtime.optionalTextResult(func(session abiString, _ *nativeMemory) *abiResult { return nativeFunctions.GetCommand(session) })
+}
+
+func (runtime *Session) GetOutput() (*string, error) {
+	return runtime.optionalTextResult(func(session abiString, _ *nativeMemory) *abiResult { return nativeFunctions.GetOutput(session) })
+}
+
+func (runtime *Session) GetCwd() (*string, error) {
+	return runtime.optionalTextResult(func(session abiString, _ *nativeMemory) *abiResult { return nativeFunctions.GetCwd(session) })
+}
+
+func (runtime *Session) GetTitle() (*string, error) {
+	return runtime.optionalTextResult(func(session abiString, _ *nativeMemory) *abiResult { return nativeFunctions.GetTitle(session) })
+}
+
+func (runtime *Session) GetClipboard() (string, error) {
+	return runtime.textResult(func(session abiString, _ *nativeMemory) *abiResult { return nativeFunctions.GetClipboard(session) })
+}
+
+func (runtime *Session) StopRecording() (string, error) {
+	return runtime.textResult(func(session abiString, _ *nativeMemory) *abiResult { return nativeFunctions.StopRecording(session) })
+}
+
+func (runtime *Session) WaitIdle(timeout *time.Duration) error {
+	duration, err := nativeDuration(timeout)
+	if err != nil {
+		return err
+	}
+	return runtime.unit(func(session abiString, _ *nativeMemory) *abiResult {
+		return nativeFunctions.WaitIdle(session, duration)
+	})
+}
+
+func (runtime *Session) WaitCommand(timeout *time.Duration) error {
+	duration, err := nativeDuration(timeout)
+	if err != nil {
+		return err
+	}
+	return runtime.unit(func(session abiString, _ *nativeMemory) *abiResult {
+		return nativeFunctions.WaitCommand(session, duration)
+	})
+}
+
+func (runtime *Session) WaitExit(timeout *time.Duration) error {
+	duration, err := nativeDuration(timeout)
+	if err != nil {
+		return err
+	}
+	return runtime.unit(func(session abiString, _ *nativeMemory) *abiResult {
+		return nativeFunctions.WaitExit(session, duration)
+	})
+}
+
+func (runtime *Session) WaitReady(timeout *time.Duration) error {
+	duration, err := nativeDuration(timeout)
+	if err != nil {
+		return err
+	}
+	return runtime.unit(func(session abiString, _ *nativeMemory) *abiResult {
+		return nativeFunctions.WaitReady(session, duration)
+	})
+}
+
+func (runtime *Session) WaitBell(timeout *time.Duration) error {
+	duration, err := nativeDuration(timeout)
+	if err != nil {
+		return err
+	}
+	return runtime.unit(func(session abiString, _ *nativeMemory) *abiResult {
+		return nativeFunctions.WaitBell(session, duration)
+	})
+}
+
+func (runtime *Session) WaitTitle(text string, options TitleOptions) error {
+	duration, err := nativeDuration(options.Timeout)
+	if err != nil {
+		return err
+	}
+	return runtime.unit(func(session abiString, memory *nativeMemory) *abiResult {
+		return nativeFunctions.WaitTitle(session, memory.text(text), abiWaitOptions{timeoutMS: duration, regex: options.Regex, not: options.Not})
+	})
+}
+
+func (runtime *Session) ExpectTitle(text string, options TitleOptions) error {
+	duration, err := nativeDuration(options.Timeout)
+	if err != nil {
+		return err
+	}
+	return runtime.unit(func(session abiString, memory *nativeMemory) *abiResult {
+		return nativeFunctions.ExpectTitle(session, memory.text(text), abiWaitOptions{timeoutMS: duration, regex: options.Regex, not: options.Not})
+	})
+}
+
+func (runtime *Session) WaitClipboard(options ClipboardWaitOptions) error {
+	duration, err := nativeDuration(options.Timeout)
+	if err != nil {
+		return err
+	}
+	return runtime.unit(func(session abiString, memory *nativeMemory) *abiResult {
+		return nativeFunctions.WaitClipboard(session, memory.optionalText(options.Text), abiWaitOptions{timeoutMS: duration, regex: options.Regex})
+	})
+}
+
+func (runtime *Session) ExpectExitCode(code int32, timeout *time.Duration) error {
+	duration, err := nativeDuration(timeout)
+	if err != nil {
+		return err
+	}
+	return runtime.unit(func(session abiString, _ *nativeMemory) *abiResult {
+		return nativeFunctions.ExpectExitCode(session, code, duration)
+	})
+}
+
+func (runtime *Session) ExpectOutput(text string, regex bool) error {
+	return runtime.unit(func(session abiString, memory *nativeMemory) *abiResult {
+		return nativeFunctions.ExpectOutput(session, memory.text(text), regex)
+	})
+}
+
+func (runtime *Session) ExpectBellCount(count uint64, timeout *time.Duration) error {
+	duration, err := nativeDuration(timeout)
+	if err != nil {
+		return err
+	}
+	return runtime.unit(func(session abiString, _ *nativeMemory) *abiResult {
+		return nativeFunctions.ExpectBellCount(session, count, duration)
+	})
+}
+
+func (runtime *Session) Screenshot(path string, options ScreenshotOptions) (string, error) {
+	return runtime.textResult(func(session abiString, memory *nativeMemory) *abiResult {
+		return nativeFunctions.Screenshot(session, options.Full, memory.nonemptyText(path), nativeFloat(options.Zoom))
+	})
+}
+
+func (runtime *Session) StartRecording(path string, options RecordingOptions) error {
+	return runtime.unit(func(session abiString, memory *nativeMemory) *abiResult {
+		return nativeFunctions.StartRecording(session, abiRecordingOptions{path: memory.text(path), format: memory.nonemptyText(string(options.Format)), fps: nativeUint(options.FPS), speed: nativeFloat(options.Speed), idleTimeLimit: nativeFloat(options.IdleTimeLimit), zoom: nativeFloat(options.Zoom)})
+	})
+}
+
+func (runtime *Session) Snapshot(name string, options SnapshotOptions) (SnapshotResult, error) {
+	var snapshot SnapshotResult
+	err := runtime.read(func(session abiString, memory *nativeMemory) *abiResult {
+		return nativeFunctions.Snapshot(session, memory.text(name), options.Update, options.IncludeColors, options.IncludeTitle, memory.nonemptyText(options.Cwd))
+	}, func(result *abiResult) {
+		switch result.snapshot {
+		case 1:
+			snapshot = SnapshotWritten
+		case 2:
+			snapshot = SnapshotUpdated
+		default:
+			snapshot = SnapshotPassed
+		}
+	})
+	return snapshot, err
+}
+
+func (runtime *Session) MouseClick(options MouseClickOptions) error {
+	mouse, err := nativeMouse(options.MouseButtonOptions)
+	if err != nil {
+		return err
+	}
+	clicks, err := nativeClicks(options.Clicks)
+	if err != nil {
+		return err
+	}
+	return runtime.unit(func(session abiString, memory *nativeMemory) *abiResult {
+		return nativeFunctions.MouseClick(session, nativeUint(options.X), nativeUint(options.Y), memory.optionalText(options.OnText), mouse, clicks)
+	})
+}
+
+func (runtime *Session) MouseMove(column, row uint16) error {
+	return runtime.unit(func(session abiString, _ *nativeMemory) *abiResult {
+		return nativeFunctions.MouseMove(session, column, row)
+	})
+}
+
+func (runtime *Session) MouseDown(column, row uint16, options MouseButtonOptions) error {
+	mouse, err := nativeMouse(options)
+	if err != nil {
+		return err
+	}
+	return runtime.unit(func(session abiString, _ *nativeMemory) *abiResult {
+		return nativeFunctions.MouseDown(session, column, row, mouse)
+	})
+}
+
+func (runtime *Session) MouseUp(column, row uint16, options MouseButtonOptions) error {
+	mouse, err := nativeMouse(options)
+	if err != nil {
+		return err
+	}
+	return runtime.unit(func(session abiString, _ *nativeMemory) *abiResult {
+		return nativeFunctions.MouseUp(session, column, row, mouse)
+	})
+}
+
+func (runtime *Session) MouseDrag(x1, y1, x2, y2 uint16, options MouseButtonOptions) error {
+	mouse, err := nativeMouse(options)
+	if err != nil {
+		return err
+	}
+	return runtime.unit(func(session abiString, _ *nativeMemory) *abiResult {
+		return nativeFunctions.MouseDrag(session, x1, y1, x2, y2, mouse)
+	})
+}
+
+func (runtime *Session) MouseScroll(direction ScrollDirection, amount uint32) error {
+	if amount > 65535 {
+		return &Error{Kind: UsageError, Message: "scroll amount must be between 0 and 65535"}
+	}
+	convertedAmount := uint16(amount)
+	return runtime.unit(func(session abiString, memory *nativeMemory) *abiResult {
+		return nativeFunctions.MouseScroll(session, memory.text(string(direction)), convertedAmount)
+	})
+}
+
+func (runtime *Session) FindLocator(stages []LocatorStage) ([]TextMatch, error) {
+	memory := nativeMemory{}
+	defer memory.release()
+	query, err := memory.query(stages)
+	if err != nil {
+		return nil, err
+	}
+	result := nativeFunctions.FindLocator(memory.text(runtime.name), query)
+	defer nativeFunctions.ResultFree(result)
+	if err := nativeError(result); err != nil {
+		return nil, err
+	}
+	return nativeMatches(result), nil
+}
+
+func (runtime *Session) locatorUnit(stages []LocatorStage, call func(abiString, abiQuery) *abiResult) error {
+	memory := nativeMemory{}
+	defer memory.release()
+	query, err := memory.query(stages)
+	if err != nil {
+		return err
+	}
+	result := call(memory.text(runtime.name), query)
+	defer nativeFunctions.ResultFree(result)
+	return nativeError(result)
+}
+
+func (runtime *Session) WaitLocator(stages []LocatorStage, hidden bool, timeout *time.Duration) error {
+	duration, err := nativeDuration(timeout)
+	if err != nil {
+		return err
+	}
+	return runtime.locatorUnit(stages, func(session abiString, query abiQuery) *abiResult {
+		return nativeFunctions.WaitLocator(session, query, abiWaitOptions{timeoutMS: duration, not: hidden})
+	})
+}
+
+func (runtime *Session) ExpectLocator(stages []LocatorStage, options LocatorExpectOptions) error {
+	return runtime.WaitLocator(stages, options.Not, options.Timeout)
+}
+
+func (runtime *Session) ClickLocator(stages []LocatorStage, options LocatorClickOptions) error {
+	duration, err := nativeDuration(options.Timeout)
+	if err != nil {
+		return err
+	}
+	mouse, err := nativeMouse(options.MouseButtonOptions)
+	if err != nil {
+		return err
+	}
+	clicks, err := nativeClicks(options.Clicks)
+	if err != nil {
+		return err
+	}
+	return runtime.locatorUnit(stages, func(session abiString, query abiQuery) *abiResult {
+		return nativeFunctions.ClickLocator(session, query, mouse, clicks, duration)
+	})
+}
+
+func (runtime *Session) HighlightLocator(stages []LocatorStage, timeout *time.Duration) error {
+	duration, err := nativeDuration(timeout)
+	if err != nil {
+		return err
+	}
+	return runtime.locatorUnit(stages, func(session abiString, query abiQuery) *abiResult {
+		return nativeFunctions.HighlightLocator(session, query, duration)
+	})
+}

--- a/bindings/go/locator.go
+++ b/bindings/go/locator.go
@@ -1,0 +1,131 @@
+package tuitest
+
+import "time"
+
+type locatorStage struct {
+	kind         string
+	text         string
+	textOptions  TextSelectorOptions
+	style        TextStyle
+	styleOptions StyleSelectorOptions
+	occurrence   string
+	nth          uint32
+}
+
+// Locator is an immutable query, resolved against the current grid on each operation.
+// Invalid selector options are reported when an operation resolves the locator.
+type Locator struct {
+	client *Client
+	stages []locatorStage
+}
+
+func (client *Client) GetByText(text string, options TextSelectorOptions) *Locator {
+	return (&Locator{client: client}).GetByText(text, options)
+}
+func (client *Client) GetByStyle(style TextStyle, options StyleSelectorOptions) *Locator {
+	return (&Locator{client: client}).GetByStyle(style, options)
+}
+func (locator *Locator) append(stage locatorStage) *Locator {
+	stages := make([]locatorStage, len(locator.stages)+1)
+	copy(stages, locator.stages)
+	stages[len(locator.stages)] = stage
+	return &Locator{client: locator.client, stages: stages}
+}
+func (locator *Locator) GetByText(text string, options TextSelectorOptions) *Locator {
+	return locator.append(locatorStage{kind: "text", text: text, textOptions: options, occurrence: "any"})
+}
+func (locator *Locator) GetByStyle(style TextStyle, options StyleSelectorOptions) *Locator {
+	style.Foreground = clonePointer(style.Foreground)
+	style.Background = clonePointer(style.Background)
+	style.Bold = clonePointer(style.Bold)
+	style.Dim = clonePointer(style.Dim)
+	style.Italic = clonePointer(style.Italic)
+	style.UnderlineStyle = clonePointer(style.UnderlineStyle)
+	style.UnderlineColor = clonePointer(style.UnderlineColor)
+	style.Inverse = clonePointer(style.Inverse)
+	style.Hidden = clonePointer(style.Hidden)
+	style.Strikethrough = clonePointer(style.Strikethrough)
+	style.Blink = clonePointer(style.Blink)
+	return locator.append(locatorStage{kind: "style", style: style, styleOptions: options, occurrence: "any"})
+}
+func (locator *Locator) selectOccurrence(occurrence string, nth uint32) *Locator {
+	stages := append([]locatorStage(nil), locator.stages...)
+	stages[len(stages)-1].occurrence = occurrence
+	stages[len(stages)-1].nth = nth
+	return &Locator{client: locator.client, stages: stages}
+}
+func (locator *Locator) Any() *Locator             { return locator.selectOccurrence("any", 0) }
+func (locator *Locator) Unique() *Locator          { return locator.selectOccurrence("unique", 0) }
+func (locator *Locator) First() *Locator           { return locator.selectOccurrence("first", 0) }
+func (locator *Locator) Last() *Locator            { return locator.selectOccurrence("last", 0) }
+func (locator *Locator) Nth(index uint32) *Locator { return locator.selectOccurrence("nth", index) }
+func (locator *Locator) strictStages() []locatorStage {
+	if locator.stages[len(locator.stages)-1].occurrence == "any" {
+		return locator.Unique().stages
+	}
+	return locator.stages
+}
+func (locator *Locator) Locations() ([]TextMatch, error) {
+	matches, err := locator.client.runtime.findLocator(locator.stages)
+	return matches, locator.client.guard("locator.locations", err)
+}
+func (locator *Locator) Location() (TextMatch, error) {
+	matches, err := locator.client.runtime.findLocator(locator.strictStages())
+	if err != nil {
+		return TextMatch{}, locator.client.guard("locator.location", err)
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	diagnostic := "no match found"
+	text, textErr := locator.client.Text(TextOptions{})
+	if textErr == nil {
+		diagnostic += "\n\nTerminal content:\n" + text
+	} else {
+		diagnostic += "\n\nTerminal content unavailable: " + textErr.Error()
+	}
+	return TextMatch{}, locator.client.guard("locator.location", &Error{Kind: AssertionError, Message: diagnostic})
+}
+func (locator *Locator) Count() (int, error) {
+	matches, err := locator.Locations()
+	return len(matches), err
+}
+func (locator *Locator) All() ([]*Locator, error) {
+	matches, err := locator.Locations()
+	if err != nil {
+		return nil, err
+	}
+	locators := make([]*Locator, len(matches))
+	for index := range matches {
+		locators[index] = locator
+		if locator.stages[len(locator.stages)-1].occurrence == "any" {
+			locators[index] = locator.Nth(uint32(index))
+		}
+	}
+	return locators, nil
+}
+func (locator *Locator) Wait(options LocatorWaitOptions) error {
+	if options.State != "" && options.State != Visible && options.State != Hidden {
+		return &Error{Kind: UsageError, Message: "locator state must be visible or hidden"}
+	}
+	return locator.client.wait("locator.wait", options.Timeout, locator.client.options.Timeouts.Text, func(timeout *time.Duration) error {
+		return locator.client.runtime.waitLocator(locator.stages, options.State == Hidden, timeout)
+	})
+}
+func (locator *Locator) Click(options LocatorClickOptions) error {
+	return locator.client.wait("locator.click", options.Timeout, locator.client.options.Timeouts.Text, func(timeout *time.Duration) error {
+		options.Timeout = timeout
+		return locator.client.runtime.clickLocator(locator.strictStages(), options)
+	})
+}
+func (locator *Locator) Highlight(options WaitOptions) error {
+	return locator.client.wait("locator.highlight", options.Timeout, locator.client.options.Timeouts.Text, func(timeout *time.Duration) error {
+		return locator.client.runtime.highlightLocator(locator.stages, timeout)
+	})
+}
+func (locator *Locator) Expect(options LocatorExpectOptions) error {
+	return locator.client.wait("locator.expect", options.Timeout, locator.client.options.Timeouts.Text, func(timeout *time.Duration) error {
+		options.Timeout = timeout
+		return locator.client.runtime.expectLocator(locator.stages, options)
+	})
+}

--- a/bindings/go/native/Cargo.toml
+++ b/bindings/go/native/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tui-test-go"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[lib]
+name = "tui_test_go"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+tui-test = { workspace = true, features = ["ghostty", "rio", "xtermjs", "recording-font-jetbrains-mono-styles"] }

--- a/bindings/go/native/src/input.rs
+++ b/bindings/go/native/src/input.rs
@@ -1,0 +1,266 @@
+use crate::types::*;
+use tui_test::api::*;
+use tui_test::profile::{Profile, Rgb};
+use tui_test::shell::Shell;
+
+type Result<T> = std::result::Result<T, TuiTestError>;
+
+impl TuiOptionalU64 {
+    pub(crate) fn option(self) -> Option<u64> {
+        self.present.then_some(self.value)
+    }
+}
+impl TuiOptionalF64 {
+    pub(crate) fn option(self) -> Option<f64> {
+        self.present.then_some(self.value)
+    }
+}
+impl TuiOptionalBool {
+    pub(crate) fn option(self) -> Option<bool> {
+        self.present.then_some(self.value)
+    }
+}
+
+// Every exported entrypoint is unsafe: the caller must provide valid readable
+// buffers for the duration of the call. Null/length and UTF-8 checks catch
+// representable usage mistakes, but cannot prove foreign pointer validity.
+pub(crate) unsafe fn slice<'a, T>(data: *const T, len: usize) -> Result<&'a [T]> {
+    if len == 0 {
+        return Ok(&[]);
+    }
+    if data.is_null() || len > isize::MAX as usize / std::mem::size_of::<T>() {
+        return Err(TuiTestError::usage(
+            "invalid native array pointer or length",
+        ));
+    }
+    Ok(unsafe { std::slice::from_raw_parts(data, len) })
+}
+impl TuiString {
+    pub(crate) unsafe fn optional(self) -> Result<Option<String>> {
+        if self.data.is_null() {
+            if self.len != 0 {
+                return Err(TuiTestError::usage(
+                    "null native string with nonzero length",
+                ));
+            }
+            return Ok(None);
+        }
+        let bytes = unsafe { slice(self.data, self.len)? };
+        std::str::from_utf8(bytes)
+            .map(|s| Some(s.to_owned()))
+            .map_err(|_| TuiTestError::usage("native string must be UTF-8"))
+    }
+    pub(crate) unsafe fn required(self) -> Result<String> {
+        unsafe { self.optional()? }
+            .ok_or_else(|| TuiTestError::usage("required native string is absent"))
+    }
+}
+pub(crate) unsafe fn strings(data: *const TuiString, len: usize) -> Result<Vec<String>> {
+    unsafe { slice(data, len)? }
+        .iter()
+        .map(|s| unsafe { s.required() })
+        .collect()
+}
+unsafe fn pairs(data: *const TuiPair, len: usize) -> Result<Vec<(String, String)>> {
+    unsafe { slice(data, len)? }
+        .iter()
+        .map(|p| Ok((unsafe { p.key.required()? }, unsafe { p.value.required()? })))
+        .collect()
+}
+pub(crate) fn u16_option(value: TuiOptionalU64, name: &str) -> Result<Option<u16>> {
+    value
+        .option()
+        .map(|v| {
+            u16::try_from(v)
+                .map_err(|_| TuiTestError::usage(format!("{name} must be between 0 and 65535")))
+        })
+        .transpose()
+}
+pub(crate) unsafe fn open(value: TuiOpenOptions) -> Result<OpenOptions> {
+    let backend = unsafe { value.backend.optional()? }
+        .map(|s| s.parse())
+        .transpose()
+        .map_err(TuiTestError::usage)?
+        .unwrap_or_default();
+    let shell = unsafe { value.shell.optional()? }
+        .map(|s| match s.as_str() {
+            "bash" => Ok(Shell::Bash),
+            "powershell" => Ok(Shell::Powershell),
+            "pwsh" => Ok(Shell::Pwsh),
+            "cmd" => Ok(Shell::Cmd),
+            "fish" => Ok(Shell::Fish),
+            "zsh" => Ok(Shell::Zsh),
+            "xonsh" => Ok(Shell::Xonsh),
+            "elvish" => Ok(Shell::Elvish),
+            "nushell" => Ok(Shell::Nushell),
+            _ => Err(TuiTestError::usage(format!("unknown shell {s:?}"))),
+        })
+        .transpose()?;
+    let mut profile = Profile::default();
+    if let Some(scrollback) = value.scrollback.option() {
+        profile.scrollback = usize::try_from(scrollback)
+            .map_err(|_| TuiTestError::usage("scrollback exceeds addressable size"))?;
+    }
+    for (name, color) in unsafe { pairs(value.colors, value.colors_len)? } {
+        let color = Rgb::parse(&color).map_err(TuiTestError::usage)?;
+        if !profile.colors.set_named(&name, color) {
+            return Err(TuiTestError::usage(format!(
+                "unknown profile color {name:?}"
+            )));
+        }
+    }
+    let mode = match unsafe { value.recording_mode.optional()? }
+        .as_deref()
+        .unwrap_or("always")
+    {
+        "always" => AutomaticRecordingMode::Always,
+        "disabled" => AutomaticRecordingMode::Disabled,
+        "on-failure" => AutomaticRecordingMode::OnFailure,
+        other => {
+            return Err(TuiTestError::usage(format!(
+                "unknown automatic recording mode {other:?}"
+            )))
+        }
+    };
+    Ok(OpenOptions {
+        backend,
+        shell,
+        profile,
+        cols: u16_option(value.cols, "cols")?.unwrap_or(80),
+        rows: u16_option(value.rows, "rows")?.unwrap_or(30),
+        cwd: unsafe { value.cwd.optional()? },
+        env: unsafe { pairs(value.env, value.env_len)? },
+        wait_ready: value.wait_ready.option(),
+        restart: value.restart,
+        timeouts: Timeouts {
+            text: value.timeouts.text.option(),
+            idle: value.timeouts.idle.option(),
+            command: value.timeouts.command.option(),
+            exit: value.timeouts.exit.option(),
+            ready: value.timeouts.ready.option(),
+        },
+        recording: AutomaticRecording {
+            mode,
+            directory: unsafe { value.recording_directory.optional()? }.map(Into::into),
+        },
+    })
+}
+pub(crate) fn mouse(value: TuiMouseOptions) -> Result<MouseOptions> {
+    let button = match value.button {
+        0 => MouseButton::Left,
+        1 => MouseButton::Middle,
+        2 => MouseButton::Right,
+        _ => return Err(TuiTestError::usage("unknown mouse button")),
+    };
+    Ok(MouseOptions {
+        button,
+        alt: value.alt,
+        ctrl: value.ctrl,
+        shift: value.shift,
+    })
+}
+fn occurrence(kind: u32, index: usize) -> Result<MatchOccurrence> {
+    match kind {
+        0 => Ok(MatchOccurrence::Any),
+        1 => Ok(MatchOccurrence::Unique),
+        2 => Ok(MatchOccurrence::First),
+        3 => Ok(MatchOccurrence::Last),
+        4 => Ok(MatchOccurrence::Nth(index)),
+        _ => Err(TuiTestError::usage("unknown match occurrence")),
+    }
+}
+unsafe fn anchor(value: TuiAnchor) -> Result<Option<TextAnchor>> {
+    unsafe { value.text.optional()? }
+        .map(|text| {
+            Ok(TextAnchor {
+                text,
+                regex: value.regex,
+                occurrence: occurrence(value.occurrence, value.index)?,
+            })
+        })
+        .transpose()
+}
+unsafe fn style(value: TuiTextStyle) -> Result<TextStyle> {
+    Ok(TextStyle {
+        foreground: unsafe { value.foreground.optional()? },
+        background: unsafe { value.background.optional()? },
+        bold: value.bold.option(),
+        dim: value.dim.option(),
+        italic: value.italic.option(),
+        underline_style: unsafe { value.underline_style.optional()? },
+        underline_color: unsafe { value.underline_color.optional()? },
+        inverse: value.inverse.option(),
+        hidden: value.hidden.option(),
+        strikethrough: value.strikethrough.option(),
+        blink: value.blink.option(),
+    })
+}
+pub(crate) unsafe fn query(value: TuiQuery, strict: bool) -> Result<LocatorQuery> {
+    let mut parent = None;
+    for stage in unsafe { slice(value.stages, value.len)? } {
+        let style = unsafe { style(stage.style)? };
+        let selector = match stage.kind {
+            0 => LocatorSelector::Text(TextSelector {
+                text: unsafe { stage.text.required()? },
+                regex: stage.regex,
+                full: stage.full,
+                whitespace: match stage.whitespace {
+                    0 => WhitespaceMode::Exact,
+                    1 => WhitespaceMode::Normalize,
+                    _ => return Err(TuiTestError::usage("unknown whitespace mode")),
+                },
+                scope: TextScope {
+                    after: unsafe { anchor(stage.after)? },
+                    before: unsafe { anchor(stage.before)? },
+                },
+            }),
+            1 => LocatorSelector::Style(StyleSelector {
+                style: style.clone(),
+                full: stage.full,
+            }),
+            _ => return Err(TuiTestError::usage("unknown locator selector kind")),
+        };
+        parent = Some(Box::new(LocatorQuery {
+            selector,
+            occurrence: occurrence(stage.occurrence, stage.index)?,
+            within: parent,
+            direction: match stage.direction {
+                0 => LocatorDirection::Within,
+                1 => LocatorDirection::After,
+                2 => LocatorDirection::Before,
+                _ => return Err(TuiTestError::usage("unknown locator direction")),
+            },
+            style,
+        }));
+    }
+    let mut query =
+        *parent.ok_or_else(|| TuiTestError::usage("locator requires at least one stage"))?;
+    if strict && query.occurrence == MatchOccurrence::Any {
+        query.occurrence = MatchOccurrence::Unique;
+    }
+    Ok(query)
+}
+pub(crate) unsafe fn recording(value: TuiRecordingOptions) -> Result<Operation> {
+    let format = unsafe { value.format.optional()? }
+        .map(|s| match s.as_str() {
+            "apng" => Ok(RecordingFormat::Apng),
+            "gif" => Ok(RecordingFormat::Gif),
+            "mp4" => Ok(RecordingFormat::Mp4),
+            "cast" => Ok(RecordingFormat::Cast),
+            _ => Err(TuiTestError::usage("unknown recording format")),
+        })
+        .transpose()?;
+    let fps = value
+        .fps
+        .option()
+        .map(|v| u8::try_from(v).map_err(|_| TuiTestError::usage("fps must be between 0 and 255")))
+        .transpose()?;
+    Ok(Operation::StartRecording {
+        path: unsafe { value.path.required()? },
+        format,
+        fps,
+        speed: value.speed.option(),
+        idle_time_limit: value.idle_time_limit.option(),
+        zoom: value.zoom.option(),
+    })
+}

--- a/bindings/go/native/src/lib.rs
+++ b/bindings/go/native/src/lib.rs
@@ -1,0 +1,801 @@
+//! Private typed C ABI for the Go binding. All borrowed input buffers must
+//! remain valid for the call. Inputs are copied before entering the engine;
+//! output storage belongs to Rust until tui_result_free is called.
+mod input;
+mod output;
+mod types;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use tui_test::api::*;
+use tui_test::runtime::global_registry;
+pub use types::*;
+
+type Result<T> = std::result::Result<T, TuiTestError>;
+fn boundary(f: impl FnOnce() -> Result<OperationResult>) -> *mut TuiResult {
+    match catch_unwind(AssertUnwindSafe(|| f().map(output::operation))) {
+        Ok(Ok(value)) => value,
+        Ok(Err(error)) => output::error(error),
+        Err(_) => output::error(TuiTestError::internal("native Go adapter panicked")),
+    }
+}
+unsafe fn execute(
+    session: TuiString,
+    operation: impl FnOnce() -> Result<Operation>,
+) -> *mut TuiResult {
+    boundary(|| {
+        let session = unsafe { session.required()? };
+        global_registry().session(session).execute(operation()?)
+    })
+}
+#[no_mangle]
+pub extern "C" fn tui_abi_version() -> u32 {
+    1
+}
+#[no_mangle]
+/// # Safety
+/// result must be NULL or a live result returned by this library, freed once.
+pub unsafe extern "C" fn tui_result_free(result: *mut TuiResult) {
+    unsafe { output::free(result) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_open(session: TuiString, options: TuiOpenOptions) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::Open(input::open(options)?))) }
+}
+#[no_mangle]
+/// Pointer form for foreign callers with limited by-value argument space.
+///
+/// # Safety
+/// options must be NULL or point to a valid TuiOpenOptions for this call.
+/// Its borrowed buffers follow the same contract as tui_open.
+pub unsafe extern "C" fn tui_open_ptr(
+    session: TuiString,
+    options: *const TuiOpenOptions,
+) -> *mut TuiResult {
+    if options.is_null() {
+        return boundary(|| Err(TuiTestError::usage("open options pointer is null")));
+    }
+    unsafe { tui_open(session, *options) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_run(
+    session: TuiString,
+    options: TuiOpenOptions,
+    program: TuiString,
+    args: *const TuiString,
+    args_len: usize,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            let o = input::open(options)?;
+            let program = program.required()?;
+            if program.is_empty() {
+                return Err(TuiTestError::usage("program must not be empty"));
+            }
+            Ok(Operation::Run(RunOptions {
+                program,
+                args: input::strings(args, args_len)?,
+                backend: o.backend,
+                profile: o.profile,
+                cols: o.cols,
+                rows: o.rows,
+                cwd: o.cwd,
+                env: o.env,
+                wait_ready: o.wait_ready,
+                restart: o.restart,
+                timeouts: o.timeouts,
+                recording: o.recording,
+            }))
+        })
+    }
+}
+#[no_mangle]
+/// Pointer form for foreign callers with limited by-value argument space.
+///
+/// # Safety
+/// options must be NULL or point to a valid TuiOpenOptions for this call.
+/// All borrowed buffers follow the same contract as tui_run.
+pub unsafe extern "C" fn tui_run_ptr(
+    session: TuiString,
+    options: *const TuiOpenOptions,
+    program: TuiString,
+    args: *const TuiString,
+    args_len: usize,
+) -> *mut TuiResult {
+    if options.is_null() {
+        return boundary(|| Err(TuiTestError::usage("run options pointer is null")));
+    }
+    unsafe { tui_run(session, *options, program, args, args_len) }
+}
+#[no_mangle]
+pub extern "C" fn tui_sessions() -> *mut TuiResult {
+    match catch_unwind(AssertUnwindSafe(|| {
+        output::sessions(global_registry().sessions())
+    })) {
+        Ok(value) => value,
+        Err(_) => output::error(TuiTestError::internal("native Go adapter panicked")),
+    }
+}
+#[no_mangle]
+pub extern "C" fn tui_close_all() -> *mut TuiResult {
+    boundary(|| {
+        global_registry().close_all();
+        Ok(OperationResult::Unit)
+    })
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_recording(session: TuiString) -> *mut TuiResult {
+    boundary(|| {
+        let session = unsafe { session.required()? };
+        global_registry()
+            .recording(&session)
+            .map(OperationResult::Recording)
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    TuiTestError::new(
+                        ErrorKind::NoSession,
+                        format!("no recording for session '{session}'"),
+                    )
+                } else {
+                    TuiTestError::internal(format!(
+                        "failed to read recording for session '{session}': {e}"
+                    ))
+                }
+            })
+    })
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_close(session: TuiString) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::Close)) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_state(session: TuiString) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::State)) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_get_command(session: TuiString) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::GetCommand)) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_get_output(session: TuiString) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::GetOutput)) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_get_exit_code(session: TuiString) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::GetExitCode)) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_get_cwd(session: TuiString) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::GetCwd)) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_get_cursor(session: TuiString) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::GetCursor)) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_get_size(session: TuiString) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::GetSize)) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_get_title(session: TuiString) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::GetTitle)) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_get_clipboard(session: TuiString) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::GetClipboard)) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_get_bell_count(session: TuiString) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::GetBellCount)) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_get_bell_events(session: TuiString) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::GetBellEvents)) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_stop_recording(session: TuiString) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::StopRecording)) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_text(session: TuiString, full: bool) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::Text { full })) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_packed_screen(session: TuiString, full: bool) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::PackedScreen { full })) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_cells(
+    session: TuiString,
+    x: u16,
+    y: u16,
+    w: u16,
+    h: u16,
+) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::Cells { x, y, w, h })) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_write(session: TuiString, text: TuiString) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::Write {
+                data: text.required()?,
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_submit(session: TuiString, text: TuiString) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::Submit {
+                data: text.optional()?,
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_signal(session: TuiString, text: TuiString) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::Signal {
+                name: text.required()?,
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_key(
+    session: TuiString,
+    keys: *const TuiString,
+    len: usize,
+    action: u32,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::Key {
+                keys: input::strings(keys, len)?,
+                action: match action {
+                    0 => KeyAction::Press,
+                    1 => KeyAction::Down,
+                    2 => KeyAction::Repeat,
+                    3 => KeyAction::Up,
+                    _ => return Err(TuiTestError::usage("unknown key action")),
+                },
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_resize(session: TuiString, cols: u16, rows: u16) -> *mut TuiResult {
+    unsafe { execute(session, || Ok(Operation::Resize { cols, rows })) }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_mouse_click(
+    session: TuiString,
+    x: TuiOptionalU64,
+    y: TuiOptionalU64,
+    on_text: TuiString,
+    options: TuiMouseOptions,
+    clicks: u8,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::Mouse {
+                action: MouseAction::Click {
+                    x: input::u16_option(x, "x")?,
+                    y: input::u16_option(y, "y")?,
+                    on_text: on_text.optional()?,
+                    options: input::mouse(options)?,
+                    clicks,
+                },
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_mouse_move(session: TuiString, x: u16, y: u16) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::Mouse {
+                action: MouseAction::Move { x, y },
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_mouse_down(
+    session: TuiString,
+    x: u16,
+    y: u16,
+    options: TuiMouseOptions,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::Mouse {
+                action: MouseAction::Down {
+                    x,
+                    y,
+                    options: input::mouse(options)?,
+                },
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_mouse_up(
+    session: TuiString,
+    x: u16,
+    y: u16,
+    options: TuiMouseOptions,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::Mouse {
+                action: MouseAction::Up {
+                    x,
+                    y,
+                    options: input::mouse(options)?,
+                },
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_mouse_drag(
+    session: TuiString,
+    x1: u16,
+    y1: u16,
+    x2: u16,
+    y2: u16,
+    options: TuiMouseOptions,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::Mouse {
+                action: MouseAction::Drag {
+                    x1,
+                    y1,
+                    x2,
+                    y2,
+                    options: input::mouse(options)?,
+                },
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_mouse_scroll(
+    session: TuiString,
+    direction: TuiString,
+    amount: u16,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::Mouse {
+                action: MouseAction::Scroll {
+                    direction: direction.required()?,
+                    amount,
+                },
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_wait_title(
+    session: TuiString,
+    text: TuiString,
+    options: TuiWaitOptions,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::WaitTitle {
+                text: text.required()?,
+                regex: options.regex,
+                not: options.not,
+                timeout_ms: options.timeout_ms.option(),
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_expect_title(
+    session: TuiString,
+    text: TuiString,
+    options: TuiWaitOptions,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::ExpectTitle {
+                text: text.required()?,
+                regex: options.regex,
+                not: options.not,
+                timeout_ms: options.timeout_ms.option(),
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_wait_clipboard(
+    session: TuiString,
+    text: TuiString,
+    options: TuiWaitOptions,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            let timeout_ms = options.timeout_ms.option();
+            match text.optional()? {
+                Some(text) => Ok(Operation::WaitClipboardMatch {
+                    pattern: if options.regex {
+                        ClipboardPattern::regex(&text)
+                            .map_err(|e| TuiTestError::usage(format!("invalid regex: {e}")))?
+                    } else {
+                        text.into()
+                    },
+                    timeout_ms,
+                }),
+                None if options.regex => Err(TuiTestError::usage("clipboard regex requires text")),
+                None => Ok(Operation::WaitClipboard { timeout_ms }),
+            }
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_wait_idle(
+    session: TuiString,
+    timeout: TuiOptionalU64,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::WaitIdle {
+                timeout_ms: timeout.option(),
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_wait_command(
+    session: TuiString,
+    timeout: TuiOptionalU64,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::WaitCommand {
+                timeout_ms: timeout.option(),
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_wait_exit(
+    session: TuiString,
+    timeout: TuiOptionalU64,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::WaitExit {
+                timeout_ms: timeout.option(),
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_wait_ready(
+    session: TuiString,
+    timeout: TuiOptionalU64,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::WaitReady {
+                timeout_ms: timeout.option(),
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_wait_bell(
+    session: TuiString,
+    timeout: TuiOptionalU64,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::WaitBell {
+                timeout_ms: timeout.option(),
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_find_locator(session: TuiString, query: TuiQuery) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::FindLocator {
+                query: input::query(query, false)?,
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_wait_locator(
+    session: TuiString,
+    query: TuiQuery,
+    options: TuiWaitOptions,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::WaitLocator {
+                query: input::query(query, false)?,
+                not: options.not,
+                timeout_ms: options.timeout_ms.option(),
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_click_locator(
+    session: TuiString,
+    query: TuiQuery,
+    options: TuiMouseOptions,
+    clicks: u8,
+    timeout: TuiOptionalU64,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::ClickLocator {
+                query: input::query(query, true)?,
+                options: input::mouse(options)?,
+                clicks,
+                timeout_ms: timeout.option(),
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_highlight_locator(
+    session: TuiString,
+    query: TuiQuery,
+    timeout: TuiOptionalU64,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::HighlightLocator {
+                query: input::query(query, false)?,
+                timeout_ms: timeout.option(),
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_expect_exit_code(
+    session: TuiString,
+    code: i32,
+    timeout: TuiOptionalU64,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::ExpectExitCode {
+                code,
+                timeout_ms: timeout.option(),
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_expect_output(
+    session: TuiString,
+    text: TuiString,
+    regex: bool,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::ExpectOutput {
+                text: text.required()?,
+                regex,
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_expect_bell_count(
+    session: TuiString,
+    count: u64,
+    timeout: TuiOptionalU64,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::ExpectBellCount {
+                count,
+                timeout_ms: timeout.option(),
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_snapshot(
+    session: TuiString,
+    name: TuiString,
+    update: bool,
+    include_colors: bool,
+    include_title: bool,
+    cwd: TuiString,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::Snapshot {
+                name: name.required()?,
+                update,
+                include_colors,
+                include_title,
+                cwd: cwd.optional()?,
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_screenshot(
+    session: TuiString,
+    full: bool,
+    path: TuiString,
+    zoom: TuiOptionalF64,
+) -> *mut TuiResult {
+    unsafe {
+        execute(session, || {
+            Ok(Operation::Screenshot {
+                full,
+                path: path.optional()?,
+                zoom: zoom.option(),
+            })
+        })
+    }
+}
+#[no_mangle]
+/// # Safety
+/// Borrowed input buffers must be valid and readable for their stated lengths
+/// throughout this call; see TuiString and the input structure contracts.
+pub unsafe extern "C" fn tui_start_recording(
+    session: TuiString,
+    options: TuiRecordingOptions,
+) -> *mut TuiResult {
+    unsafe { execute(session, || input::recording(options)) }
+}
+#[cfg(test)]
+mod tests;

--- a/bindings/go/native/src/output.rs
+++ b/bindings/go/native/src/output.rs
@@ -1,0 +1,236 @@
+use crate::types::*;
+use tui_test::api::*;
+
+#[derive(Default)]
+struct Storage {
+    bytes: Vec<Box<[u8]>>,
+    cells: Vec<TuiCell>,
+    matches: Vec<TuiMatch>,
+    spans: Vec<Box<[TuiSpan]>>,
+    bells: Vec<TuiBellEvent>,
+    strings: Vec<TuiString>,
+}
+impl Storage {
+    fn bytes(&mut self, value: Vec<u8>) -> TuiString {
+        let value = value.into_boxed_slice();
+        let output = TuiString {
+            data: value.as_ptr(),
+            len: value.len(),
+        };
+        self.bytes.push(value);
+        output
+    }
+    fn string(&mut self, value: String) -> TuiString {
+        self.bytes(value.into_bytes())
+    }
+    fn optional(&mut self, value: Option<String>) -> TuiString {
+        value.map(|s| self.string(s)).unwrap_or_default()
+    }
+}
+fn integer(value: Option<i32>) -> TuiOptionalI32 {
+    TuiOptionalI32 {
+        present: value.is_some(),
+        value: value.unwrap_or_default(),
+    }
+}
+fn unsigned(value: u64) -> TuiOptionalU64 {
+    TuiOptionalU64 {
+        present: true,
+        value,
+    }
+}
+fn color(value: CellColor) -> TuiColor {
+    match value {
+        CellColor::Default => TuiColor::default(),
+        CellColor::Indexed(index) => TuiColor {
+            kind: 1,
+            index,
+            ..Default::default()
+        },
+        CellColor::Rgb(red, green, blue) => TuiColor {
+            kind: 2,
+            red,
+            green,
+            blue,
+            ..Default::default()
+        },
+    }
+}
+fn complete(mut result: TuiResult, storage: Storage) -> *mut TuiResult {
+    result.private_data = Box::into_raw(Box::new(storage)).cast();
+    Box::into_raw(Box::new(result))
+}
+pub(crate) fn error(error: TuiTestError) -> *mut TuiResult {
+    let mut storage = Storage::default();
+    let result = TuiResult {
+        error_kind: error.kind.exit_code() as u32,
+        error_message: storage.string(error.message),
+        ..Default::default()
+    };
+    complete(result, storage)
+}
+pub(crate) fn sessions(names: Vec<String>) -> *mut TuiResult {
+    let mut storage = Storage::default();
+    for name in names {
+        let value = storage.string(name);
+        storage.strings.push(value);
+    }
+    let result = TuiResult {
+        strings: storage.strings.as_ptr(),
+        strings_len: storage.strings.len(),
+        ..Default::default()
+    };
+    complete(result, storage)
+}
+pub(crate) fn operation(value: OperationResult) -> *mut TuiResult {
+    let mut s = Storage::default();
+    let mut r = TuiResult::default();
+    match value {
+        OperationResult::Unit => {}
+        OperationResult::Open(v) => {
+            r.open = TuiOpenResult {
+                shell_pid: TuiOptionalU64 {
+                    present: v.shell_pid.is_some(),
+                    value: u64::from(v.shell_pid.unwrap_or_default()),
+                },
+                session: s.string(v.session),
+                ready: v.ready,
+                recording: s.string(v.recording),
+            }
+        }
+        OperationResult::State(v) => {
+            r.state = TuiState {
+                session_shell: s.optional(v.session_shell),
+                cols: v.cols,
+                rows: v.rows,
+                cursor: TuiCursor {
+                    x: v.cursor.x,
+                    y: v.cursor.y,
+                },
+                title: s.optional(v.title),
+                cwd: s.optional(v.cwd),
+                last_command: s.optional(v.last_command),
+                last_exit: integer(v.last_exit),
+                exited: integer(v.exited),
+                ready: v.ready,
+                bell_count: v.bell_count,
+                timeouts: TuiTimeouts {
+                    text: unsigned(v.timeouts.text),
+                    idle: unsigned(v.timeouts.idle),
+                    command: unsigned(v.timeouts.command),
+                    exit: unsigned(v.timeouts.exit),
+                    ready: unsigned(v.timeouts.ready),
+                },
+                text: s.string(v.text),
+            }
+        }
+        OperationResult::Text(v)
+        | OperationResult::Clipboard(v)
+        | OperationResult::Recording(v) => r.text = s.string(v),
+        OperationResult::Command(v)
+        | OperationResult::Output(v)
+        | OperationResult::Cwd(v)
+        | OperationResult::Title(v) => r.text = s.optional(v),
+        OperationResult::ExitCode(v) => r.exit_code = integer(v),
+        OperationResult::Cursor(v) => r.cursor = TuiCursor { x: v.x, y: v.y },
+        OperationResult::Size(v) => {
+            r.size = TuiSize {
+                cols: v.cols,
+                rows: v.rows,
+            }
+        }
+        OperationResult::BellCount(v) => r.number = v,
+        OperationResult::PackedScreen(v) => {
+            r.size = TuiSize {
+                cols: v.cols,
+                rows: v.rows,
+            };
+            r.text = s.bytes(v.utf8);
+        }
+        OperationResult::Cells(v) => {
+            for c in v {
+                let cell = TuiCell {
+                    x: c.x,
+                    y: c.y,
+                    character: s.string(c.char),
+                    fg: color(c.fg),
+                    bg: color(c.bg),
+                    bold: c.bold,
+                    dim: c.dim,
+                    italic: c.italic,
+                    inverse: c.inverse,
+                    invisible: c.invisible,
+                    strike: c.strike,
+                    blink: c.blink,
+                    underline: c.underline,
+                    underline_style: s.string(c.underline_style),
+                    underline_color: color(c.underline_color),
+                };
+                s.cells.push(cell);
+            }
+            r.cells = s.cells.as_ptr();
+            r.cells_len = s.cells.len();
+        }
+        OperationResult::Matches(v) => {
+            for m in v {
+                let spans = m
+                    .spans
+                    .into_iter()
+                    .map(|v| TuiSpan {
+                        row: v.row,
+                        start: v.start,
+                        end: v.end,
+                    })
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice();
+                let value = TuiMatch {
+                    text: s.string(m.text),
+                    start: TuiPosition {
+                        row: m.start.row,
+                        column: m.start.column,
+                    },
+                    end: TuiPosition {
+                        row: m.end.row,
+                        column: m.end.column,
+                    },
+                    spans: spans.as_ptr(),
+                    spans_len: spans.len(),
+                };
+                s.spans.push(spans);
+                s.matches.push(value);
+            }
+            r.matches = s.matches.as_ptr();
+            r.matches_len = s.matches.len();
+        }
+        OperationResult::BellEvents(v) => {
+            s.bells = v
+                .into_iter()
+                .map(|v| TuiBellEvent {
+                    sequence: v.sequence,
+                    elapsed_ms: v.elapsed_ms,
+                })
+                .collect();
+            r.bells = s.bells.as_ptr();
+            r.bells_len = s.bells.len();
+        }
+        OperationResult::Snapshot(v) => {
+            r.snapshot = match v {
+                SnapshotResult::Passed => 0,
+                SnapshotResult::Written => 1,
+                SnapshotResult::Updated => 2,
+            }
+        }
+        OperationResult::Screenshot(ScreenshotResult::Path(v) | ScreenshotResult::Text(v)) => {
+            r.text = s.string(v)
+        }
+    }
+    complete(r, s)
+}
+/// # Safety
+/// result must be NULL or a live result returned by this library, freed once.
+pub(crate) unsafe fn free(result: *mut TuiResult) {
+    if !result.is_null() {
+        let result = unsafe { Box::from_raw(result) };
+        drop(unsafe { Box::from_raw(result.private_data.cast::<Storage>()) });
+    }
+}

--- a/bindings/go/native/src/tests.rs
+++ b/bindings/go/native/src/tests.rs
@@ -1,0 +1,170 @@
+use super::*;
+
+fn text(value: &str) -> TuiString {
+    TuiString {
+        data: value.as_ptr(),
+        len: value.len(),
+    }
+}
+unsafe fn message(result: *mut TuiResult) -> String {
+    unsafe { (*result).error_message.required().unwrap() }
+}
+
+#[test]
+fn missing_sessions_retain_structured_errors_and_owned_messages() {
+    for _ in 0..128 {
+        let result = unsafe { tui_state(text("go-abi-missing-session")) };
+        assert_eq!(unsafe { (*result).error_kind }, 3);
+        assert!(unsafe { message(result) }.contains("no active session"));
+        unsafe { tui_result_free(result) };
+    }
+    unsafe { tui_result_free(std::ptr::null_mut()) };
+}
+
+#[test]
+fn pointer_options_reject_null_and_preserve_validation() {
+    let session = text("go-abi-pointer-options");
+    let options = TuiOpenOptions {
+        cols: TuiOptionalU64 {
+            present: true,
+            value: 65_536,
+        },
+        ..Default::default()
+    };
+    let results = unsafe {
+        [
+            tui_open_ptr(session, std::ptr::null()),
+            tui_run_ptr(session, std::ptr::null(), text(""), std::ptr::null(), 0),
+            tui_open_ptr(session, &options),
+            tui_run_ptr(session, &options, text(""), std::ptr::null(), 0),
+        ]
+    };
+    for result in results {
+        assert_eq!(unsafe { (*result).error_kind }, 2);
+        unsafe { tui_result_free(result) };
+    }
+}
+#[test]
+fn panic_is_contained_and_next_call_succeeds() {
+    let result = boundary(|| panic!("intentional boundary test"));
+    assert_eq!(unsafe { (*result).error_kind }, 5);
+    assert!(unsafe { message(result) }.contains("panicked"));
+    unsafe { tui_result_free(result) };
+    let result = unsafe { tui_close(text("go-abi-missing-session")) };
+    assert_eq!(unsafe { (*result).error_kind }, 0);
+    unsafe { tui_result_free(result) };
+}
+#[test]
+fn invalid_utf8_and_absent_required_inputs_report_usage() {
+    let bytes = [0xff];
+    for session in [
+        TuiString::default(),
+        TuiString {
+            data: bytes.as_ptr(),
+            len: 1,
+        },
+        TuiString {
+            data: std::ptr::null(),
+            len: 1,
+        },
+    ] {
+        let result = unsafe { tui_state(session) };
+        assert_eq!(unsafe { (*result).error_kind }, 2);
+        unsafe { tui_result_free(result) };
+    }
+}
+#[test]
+fn input_conversion_preserves_explicit_zero_false_and_empty_values() {
+    let options = TuiOpenOptions {
+        cols: TuiOptionalU64 {
+            present: true,
+            value: 0,
+        },
+        wait_ready: TuiOptionalBool {
+            present: true,
+            value: false,
+        },
+        cwd: text(""),
+        ..Default::default()
+    };
+    let converted = unsafe { input::open(options).unwrap() };
+    assert_eq!(converted.cols, 0);
+    assert_eq!(converted.rows, 30);
+    assert_eq!(converted.wait_ready, Some(false));
+    assert_eq!(converted.cwd, Some(String::new()));
+    let absent = unsafe { input::open(TuiOpenOptions::default()).unwrap() };
+    assert_eq!(absent.cols, 80);
+    assert_eq!(absent.wait_ready, None);
+    assert_eq!(absent.cwd, None);
+}
+#[test]
+fn output_buffers_preserve_nuls_unicode_and_absence() {
+    let expected = "a\0界🙂";
+    let result = output::operation(OperationResult::Text(expected.into()));
+    assert_eq!(unsafe { (*result).text.required().unwrap() }, expected);
+    unsafe { tui_result_free(result) };
+    let result = output::operation(OperationResult::Title(None));
+    assert!(unsafe { (*result).text.data.is_null() });
+    unsafe { tui_result_free(result) };
+    let result = output::operation(OperationResult::Title(Some(String::new())));
+    assert!(!unsafe { (*result).text.data.is_null() });
+    assert_eq!(unsafe { (*result).text.len }, 0);
+    unsafe { tui_result_free(result) };
+}
+#[test]
+fn locator_stages_preserve_parent_selection_and_strict_action_semantics() {
+    let stages = [
+        TuiLocatorStage {
+            text: text("parent"),
+            occurrence: 4,
+            index: 2,
+            ..Default::default()
+        },
+        TuiLocatorStage {
+            text: text("child"),
+            direction: 1,
+            style: TuiTextStyle {
+                bold: TuiOptionalBool {
+                    present: true,
+                    value: false,
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    ];
+    let query = TuiQuery {
+        stages: stages.as_ptr(),
+        len: stages.len(),
+    };
+    let converted = unsafe { input::query(query, true).unwrap() };
+    assert_eq!(converted.occurrence, MatchOccurrence::Unique);
+    assert_eq!(converted.direction, LocatorDirection::After);
+    assert_eq!(converted.style.bold, Some(false));
+    assert_eq!(
+        converted.within.unwrap().occurrence,
+        MatchOccurrence::Nth(2)
+    );
+    assert_eq!(
+        unsafe { input::query(query, false).unwrap() }.occurrence,
+        MatchOccurrence::Any
+    );
+}
+#[test]
+fn match_output_owns_nested_spans() {
+    let result = output::operation(OperationResult::Matches(vec![TextMatch {
+        text: "界".into(),
+        start: TextPosition { row: 3, column: 2 },
+        end: TextPosition { row: 3, column: 4 },
+        spans: vec![TextSpan {
+            row: 3,
+            start: 2,
+            end: 4,
+        }],
+    }]));
+    let matches = unsafe { input::slice((*result).matches, (*result).matches_len).unwrap() };
+    assert_eq!(unsafe { matches[0].text.required().unwrap() }, "界");
+    let spans = unsafe { input::slice(matches[0].spans, matches[0].spans_len).unwrap() };
+    assert_eq!(spans[0].end, 4);
+    unsafe { tui_result_free(result) };
+}

--- a/bindings/go/native/src/types.rs
+++ b/bindings/go/native/src/types.rs
@@ -1,0 +1,262 @@
+use std::ffi::c_void;
+
+/// A borrowed UTF-8 byte string. NULL denotes absence; a non-NULL pointer
+/// with zero length denotes an explicitly empty string. Inputs live through
+/// the call only. All output pointers live until tui_result_free.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiString {
+    pub data: *const u8,
+    pub len: usize,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiOptionalU64 {
+    pub present: bool,
+    pub value: u64,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiOptionalI32 {
+    pub present: bool,
+    pub value: i32,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiOptionalBool {
+    pub present: bool,
+    pub value: bool,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiOptionalF64 {
+    pub present: bool,
+    pub value: f64,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiPair {
+    pub key: TuiString,
+    pub value: TuiString,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiTimeouts {
+    pub text: TuiOptionalU64,
+    pub idle: TuiOptionalU64,
+    pub command: TuiOptionalU64,
+    pub exit: TuiOptionalU64,
+    pub ready: TuiOptionalU64,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiOpenOptions {
+    pub backend: TuiString,
+    pub shell: TuiString,
+    pub cols: TuiOptionalU64,
+    pub rows: TuiOptionalU64,
+    pub cwd: TuiString,
+    pub env: *const TuiPair,
+    pub env_len: usize,
+    pub wait_ready: TuiOptionalBool,
+    pub restart: bool,
+    pub scrollback: TuiOptionalU64,
+    pub colors: *const TuiPair,
+    pub colors_len: usize,
+    pub timeouts: TuiTimeouts,
+    pub recording_mode: TuiString,
+    pub recording_directory: TuiString,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiTextStyle {
+    pub foreground: TuiString,
+    pub background: TuiString,
+    pub bold: TuiOptionalBool,
+    pub dim: TuiOptionalBool,
+    pub italic: TuiOptionalBool,
+    pub underline_style: TuiString,
+    pub underline_color: TuiString,
+    pub inverse: TuiOptionalBool,
+    pub hidden: TuiOptionalBool,
+    pub strikethrough: TuiOptionalBool,
+    pub blink: TuiOptionalBool,
+}
+/// occurrence: 0 any, 1 unique, 2 first, 3 last, 4 nth.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiAnchor {
+    pub text: TuiString,
+    pub regex: bool,
+    pub occurrence: u32,
+    pub index: usize,
+}
+/// kind: 0 text, 1 style. direction: 0 within, 1 after, 2 before.
+/// whitespace: 0 exact, 1 normalize. Stages are ordered parent first.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiLocatorStage {
+    pub kind: u32,
+    pub text: TuiString,
+    pub regex: bool,
+    pub full: bool,
+    pub whitespace: u32,
+    pub after: TuiAnchor,
+    pub before: TuiAnchor,
+    pub style: TuiTextStyle,
+    pub occurrence: u32,
+    pub index: usize,
+    pub direction: u32,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiQuery {
+    pub stages: *const TuiLocatorStage,
+    pub len: usize,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiWaitOptions {
+    pub timeout_ms: TuiOptionalU64,
+    pub regex: bool,
+    pub not: bool,
+}
+/// button: 0 left, 1 middle, 2 right.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiMouseOptions {
+    pub button: u32,
+    pub alt: bool,
+    pub ctrl: bool,
+    pub shift: bool,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiRecordingOptions {
+    pub path: TuiString,
+    pub format: TuiString,
+    pub fps: TuiOptionalU64,
+    pub speed: TuiOptionalF64,
+    pub idle_time_limit: TuiOptionalF64,
+    pub zoom: TuiOptionalF64,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiCursor {
+    pub x: u16,
+    pub y: u16,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiSize {
+    pub cols: u16,
+    pub rows: u16,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiOpenResult {
+    pub shell_pid: TuiOptionalU64,
+    pub session: TuiString,
+    pub ready: bool,
+    pub recording: TuiString,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiState {
+    pub session_shell: TuiString,
+    pub cols: u16,
+    pub rows: u16,
+    pub cursor: TuiCursor,
+    pub title: TuiString,
+    pub cwd: TuiString,
+    pub last_command: TuiString,
+    pub last_exit: TuiOptionalI32,
+    pub exited: TuiOptionalI32,
+    pub ready: bool,
+    pub bell_count: u64,
+    pub timeouts: TuiTimeouts,
+    pub text: TuiString,
+}
+/// kind: 0 default, 1 indexed (index), 2 RGB (red/green/blue).
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiColor {
+    pub kind: u32,
+    pub index: u8,
+    pub red: u8,
+    pub green: u8,
+    pub blue: u8,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiCell {
+    pub x: u16,
+    pub y: u16,
+    pub character: TuiString,
+    pub fg: TuiColor,
+    pub bg: TuiColor,
+    pub bold: bool,
+    pub dim: bool,
+    pub italic: bool,
+    pub inverse: bool,
+    pub invisible: bool,
+    pub strike: bool,
+    pub blink: bool,
+    pub underline: bool,
+    pub underline_style: TuiString,
+    pub underline_color: TuiColor,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiPosition {
+    pub row: u32,
+    pub column: u16,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiSpan {
+    pub row: u32,
+    pub start: u16,
+    pub end: u16,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiMatch {
+    pub text: TuiString,
+    pub start: TuiPosition,
+    pub end: TuiPosition,
+    pub spans: *const TuiSpan,
+    pub spans_len: usize,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct TuiBellEvent {
+    pub sequence: u64,
+    pub elapsed_ms: u64,
+}
+/// The function called determines the populated success field. error_kind is
+/// 0 on success, 1 assertion, 2 usage, 3 no-session, 5 internal.
+/// snapshot: 0 passed, 1 written, 2 updated. Free exactly once.
+#[repr(C)]
+#[derive(Default)]
+pub struct TuiResult {
+    pub error_kind: u32,
+    pub error_message: TuiString,
+    pub text: TuiString,
+    pub number: u64,
+    pub exit_code: TuiOptionalI32,
+    pub open: TuiOpenResult,
+    pub state: TuiState,
+    pub cursor: TuiCursor,
+    pub size: TuiSize,
+    pub cells: *const TuiCell,
+    pub cells_len: usize,
+    pub matches: *const TuiMatch,
+    pub matches_len: usize,
+    pub bells: *const TuiBellEvent,
+    pub bells_len: usize,
+    pub strings: *const TuiString,
+    pub strings_len: usize,
+    pub snapshot: u32,
+    pub private_data: *mut c_void,
+}

--- a/bindings/go/native_pointer_test.go
+++ b/bindings/go/native_pointer_test.go
@@ -1,0 +1,35 @@
+package tuitest
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNativeOptionPointersPreserveValidation(t *testing.T) {
+	terminal, err := Ephemeral(t.Name(), ClientOptions{Recording: &AutomaticRecording{Mode: RecordingDisabled}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if closeErr := terminal.Close(); closeErr != nil {
+			t.Error(closeErr)
+		}
+	})
+	options := SpawnOptions{Backend: Backend("invalid-native-backend")}
+	t.Run("open", func(t *testing.T) {
+		_, openErr := terminal.Open(OpenOptions{SpawnOptions: options})
+		requireNativeUsageError(t, openErr)
+	})
+	t.Run("run", func(t *testing.T) {
+		_, runErr := terminal.Run("unused-program", nil, options)
+		requireNativeUsageError(t, runErr)
+	})
+}
+
+func requireNativeUsageError(t *testing.T, err error) {
+	t.Helper()
+	var failure *Error
+	if !errors.As(err, &failure) || failure.Kind != UsageError {
+		t.Fatalf("expected native usage error, got %v", err)
+	}
+}

--- a/bindings/go/spawn_test.go
+++ b/bindings/go/spawn_test.go
@@ -1,0 +1,122 @@
+package tuitest_test
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	tuitest "github.com/microsoft/tui-test/bindings/go"
+)
+
+func TestRetryTerminalProcess(t *testing.T) {
+	if !slices.Contains(os.Args, "--tui-go-retry-child") {
+		return
+	}
+	const marker = "first-launch"
+	_, err := os.Stat(marker)
+	if errors.Is(err, os.ErrNotExist) {
+		requireNoError(t, os.WriteFile(marker, []byte("first launch"), 0600))
+	} else {
+		requireNoError(t, err)
+		fmt.Print("\x1b]133;B\x07retry-ready\r\n")
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		fmt.Printf("received:%s\r\n", scanner.Text())
+	}
+	requireNoError(t, scanner.Err())
+	os.Exit(0)
+}
+
+func clientLaunchTimeouts() tuitest.Timeouts {
+	return tuitest.Timeouts{
+		Text: tuitest.Ptr(11 * time.Millisecond), Idle: tuitest.Ptr(12 * time.Millisecond),
+		Command: tuitest.Ptr(13 * time.Millisecond), Exit: tuitest.Ptr(14 * time.Millisecond),
+		Ready: tuitest.Ptr(15 * time.Millisecond),
+	}
+}
+
+type launchTimeoutCase struct {
+	name     string
+	options  tuitest.Timeouts
+	expected tuitest.EffectiveTimeouts
+}
+
+func launchTimeoutCases() []launchTimeoutCase {
+	zero := time.Duration(0)
+	return []launchTimeoutCase{
+		{name: "inherit", expected: tuitest.EffectiveTimeouts{Text: 11 * time.Millisecond, Idle: 12 * time.Millisecond, Command: 13 * time.Millisecond, Exit: 14 * time.Millisecond, Ready: 15 * time.Millisecond}},
+		{name: "partial override", options: tuitest.Timeouts{Text: &zero, Ready: tuitest.Ptr(42 * time.Millisecond)}, expected: tuitest.EffectiveTimeouts{Idle: 12 * time.Millisecond, Command: 13 * time.Millisecond, Exit: 14 * time.Millisecond, Ready: 42 * time.Millisecond}},
+		{name: "explicit zero", options: tuitest.Timeouts{Text: &zero, Idle: &zero, Command: &zero, Exit: &zero, Ready: &zero}},
+	}
+}
+
+func TestClientTimeoutDefaultsReachLaunch(t *testing.T) {
+	for _, launch := range []string{"open", "run"} {
+		for _, testCase := range launchTimeoutCases() {
+			t.Run(launch+"/"+testCase.name, func(t *testing.T) { verifyLaunchTimeouts(t, launch, testCase) })
+		}
+	}
+}
+
+func verifyLaunchTimeouts(t *testing.T, launch string, testCase launchTimeoutCase) {
+	t.Helper()
+	terminal := newClient(t, tuitest.ClientOptions{Timeouts: clientLaunchTimeouts()})
+	options := tuitest.SpawnOptions{WaitReady: tuitest.Ptr(false), Timeouts: testCase.options}
+	if launch == "run" {
+		runTerminal(t, terminal, options)
+	} else {
+		_, err := terminal.Open(tuitest.OpenOptions{SpawnOptions: options})
+		requireNoError(t, err)
+	}
+	state, err := terminal.State()
+	requireNoError(t, err)
+	if state.Timeouts != testCase.expected {
+		t.Fatalf("launch timeouts=%+v, expected %+v", state.Timeouts, testCase.expected)
+	}
+}
+
+func TestInvalidLaunchRetryPreservesSharedSession(t *testing.T) {
+	for _, launch := range []string{"open", "run"} {
+		t.Run(launch, func(t *testing.T) {
+			terminal := newTerminal(t, tuitest.ClientOptions{})
+			peer, err := tuitest.New(terminal.Session(), tuitest.ClientOptions{})
+			requireNoError(t, err)
+			options := tuitest.SpawnOptions{Backend: tuitest.Backend("unknown"), Retries: 1, Restart: tuitest.Ptr(false)}
+			if launch == "run" {
+				_, err = peer.Run("ignored", nil, options)
+			} else {
+				_, err = peer.Open(tuitest.OpenOptions{SpawnOptions: options})
+			}
+			requireKind(t, err, tuitest.UsageError)
+			requireNoError(t, terminal.GetByText("go-ready", tuitest.TextSelectorOptions{}).Expect(tuitest.LocatorExpectOptions{Timeout: tuitest.Ptr(time.Duration(0))}))
+			requireNoError(t, terminal.Submit(tuitest.Ptr("session-survived")))
+			requireNoError(t, peer.GetByText("received:session-survived", tuitest.TextSelectorOptions{}).Expect(tuitest.LocatorExpectOptions{Timeout: tuitest.Ptr(time.Second)}))
+		})
+	}
+}
+
+func TestLaunchRetriesReadinessFailure(t *testing.T) {
+	directory := t.TempDir()
+	terminal := newClient(t, tuitest.ClientOptions{})
+	executable, err := os.Executable()
+	requireNoError(t, err)
+	marker := filepath.Join(directory, "first-launch")
+	result, err := terminal.Run(executable, []string{"-test.run=^TestRetryTerminalProcess$", "--", "--tui-go-retry-child"}, tuitest.SpawnOptions{
+		Cwd: directory, WaitReady: tuitest.Ptr(true), Retries: 1,
+		Timeouts: tuitest.Timeouts{Ready: tuitest.Ptr(3 * time.Second)},
+	})
+	requireNoError(t, err)
+	if !result.Ready {
+		t.Fatal("retry returned before the second launch was ready")
+	}
+	_, err = os.Stat(marker)
+	requireNoError(t, err)
+	requireNoError(t, terminal.Submit(tuitest.Ptr("retried")))
+	requireNoError(t, terminal.GetByText("received:retried", tuitest.TextSelectorOptions{}).Expect(tuitest.LocatorExpectOptions{Timeout: tuitest.Ptr(3 * time.Second)}))
+}

--- a/bindings/go/tuitesttest/terminal.go
+++ b/bindings/go/tuitesttest/terminal.go
@@ -1,0 +1,103 @@
+// Package tuitesttest integrates terminal sessions with Go test cleanup.
+package tuitesttest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tuitest "github.com/microsoft/tui-test/bindings/go"
+)
+
+// Options are per-test defaults; there is no process-wide mutable configuration.
+type Options struct {
+	Client  tuitest.ClientOptions
+	Spawn   tuitest.SpawnOptions
+	Shell   tuitest.Shell
+	Program string
+	Args    []string
+	Prefix  string
+}
+
+// New opens a unique terminal and registers cleanup even if spawning fails.
+// If Client.Artifacts is configured, failed tests save artifacts before closing.
+func New(tb testing.TB, options Options) *tuitest.Client {
+	tb.Helper()
+	prefix := options.Prefix
+	if prefix == "" {
+		prefix = tb.Name()
+	}
+	terminal, err := tuitest.Ephemeral(prefix, options.Client)
+	if err != nil {
+		tb.Fatalf("create terminal: %v", err)
+		return nil
+	}
+	tb.Cleanup(func() {
+		if tb.Failed() {
+			captureFailure(tb, terminal, options.Client.Artifacts)
+		}
+		if closeErr := terminal.Close(); closeErr != nil {
+			tb.Errorf("close terminal: %v", closeErr)
+		}
+	})
+	if options.Program == "" {
+		_, err = terminal.Open(tuitest.OpenOptions{SpawnOptions: options.Spawn, Shell: options.Shell})
+	} else {
+		_, err = terminal.Run(options.Program, options.Args, options.Spawn)
+	}
+	if err != nil {
+		tb.Fatalf("spawn terminal: %v", err)
+	}
+	return terminal
+}
+
+func captureFailure(tb testing.TB, terminal *tuitest.Client, options *tuitest.ArtifactOptions) {
+	tb.Helper()
+	if options == nil || options.OnFailure == tuitest.ArtifactNone {
+		return
+	}
+	if err := os.MkdirAll(options.Dir, 0755); err != nil {
+		tb.Logf("terminal artifact: %v", err)
+		return
+	}
+	filename := filepath.Join(options.Dir, terminal.Session())
+	path, err := saveArtifact(terminal, filename, options.OnFailure)
+	if err != nil {
+		tb.Logf("terminal artifact: %v", err)
+	} else {
+		tb.Logf("terminal artifact: %s", path)
+	}
+}
+
+func saveArtifact(terminal *tuitest.Client, filename string, mode tuitest.ArtifactMode) (string, error) {
+	if mode != tuitest.ArtifactText {
+		path, err := terminal.Screenshot(filename+".svg", tuitest.ScreenshotOptions{})
+		if err != nil {
+			return "", fmt.Errorf("save terminal screenshot: %w", err)
+		}
+		return path, nil
+	}
+	text, err := terminal.Text(tuitest.TextOptions{})
+	if err != nil {
+		return "", fmt.Errorf("read terminal text: %w", err)
+	}
+	path := filename + ".txt"
+	if err = os.WriteFile(path, []byte(text), 0644); err != nil {
+		return "", fmt.Errorf("save terminal text: %w", err)
+	}
+	return path, nil
+}
+
+// TerminalSnapshot removes trailing whitespace and blank lines for text comparisons.
+func TerminalSnapshot(text string) string {
+	lines := strings.Split(text, "\n")
+	for index, line := range lines {
+		lines[index] = strings.TrimRight(line, " \t\r")
+	}
+	for len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/bindings/go/tuitesttest/terminal_test.go
+++ b/bindings/go/tuitesttest/terminal_test.go
@@ -1,0 +1,123 @@
+package tuitesttest_test
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	tuitest "github.com/microsoft/tui-test/bindings/go"
+	"github.com/microsoft/tui-test/bindings/go/tuitesttest"
+)
+
+func TestHelperChild(t *testing.T) {
+	if !slices.Contains(os.Args, "--helper-child") {
+		return
+	}
+	fmt.Println("helper-ready")
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		if scanner.Text() == "quit" {
+			os.Exit(0)
+		}
+	}
+	os.Exit(0)
+}
+
+func helperOptions(t *testing.T) tuitesttest.Options {
+	t.Helper()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tuitesttest.Options{
+		Client:  tuitest.ClientOptions{Recording: &tuitest.AutomaticRecording{Mode: tuitest.RecordingDisabled}},
+		Spawn:   tuitest.SpawnOptions{WaitReady: tuitest.Ptr(false)},
+		Program: executable, Args: []string{"-test.run=^TestHelperChild$", "--", "--helper-child"},
+	}
+}
+
+func TestCleanupAndParallelIsolation(t *testing.T) {
+	names := make(chan string, 2)
+	t.Cleanup(func() {
+		close(names)
+		verifyClosedSessions(t, names)
+	})
+	for _, name := range []string{"one", "two"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			terminal := tuitesttest.New(t, helperOptions(t))
+			names <- terminal.Session()
+			if err := terminal.GetByText("helper-ready", tuitest.TextSelectorOptions{}).Expect(tuitest.LocatorExpectOptions{Timeout: tuitest.Ptr(10 * time.Second)}); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func verifyClosedSessions(t *testing.T, names <-chan string) {
+	t.Helper()
+	remaining, err := tuitest.Sessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := ""
+	for name := range names {
+		if slices.Contains(remaining, name) {
+			t.Errorf("session %s survived cleanup", name)
+		}
+		if previous == name {
+			t.Errorf("parallel tests shared session %s", name)
+		}
+		previous = name
+	}
+}
+
+func TestFailureArtifacts(t *testing.T) {
+	if directory := os.Getenv("TUI_GO_HELPER_FAILURE_DIR"); directory != "" {
+		runFailingTest(t, directory)
+		return
+	}
+	directory := t.TempDir()
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command(executable, "-test.run=^TestFailureArtifacts$") //nolint:gosec // G204: Re-executes this test binary with fixed arguments to verify failure artifacts.
+	command.Env = append(os.Environ(), "TUI_GO_HELPER_FAILURE_DIR="+directory)
+	output, err := command.CombinedOutput()
+	var exitError *exec.ExitError
+	if !errors.As(err, &exitError) || exitError.ExitCode() != 1 {
+		t.Fatalf("child error=%v output=%s", err, output)
+	}
+	matches, err := filepath.Glob(filepath.Join(directory, "*.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("failure artifacts=%v output=%s", matches, output)
+	}
+}
+
+func runFailingTest(t *testing.T, directory string) {
+	t.Helper()
+	options := helperOptions(t)
+	options.Client.Artifacts = &tuitest.ArtifactOptions{Dir: directory, OnFailure: tuitest.ArtifactText}
+	terminal := tuitesttest.New(t, options)
+	if err := terminal.GetByText("helper-ready", tuitest.TextSelectorOptions{}).Expect(tuitest.LocatorExpectOptions{Timeout: tuitest.Ptr(10 * time.Second)}); err != nil {
+		t.Fatal(err)
+	}
+	t.Error("intentional failure to exercise registered cleanup")
+}
+
+func TestTerminalSnapshot(t *testing.T) {
+	actual := tuitesttest.TerminalSnapshot("one  \r\n two\t\n\n")
+	if actual != "one\n two" {
+		t.Fatalf("snapshot=%q", actual)
+	}
+}

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -1,0 +1,286 @@
+// Package tuitest drives terminal programs through the in-process tui-test engine.
+package tuitest
+
+import "time"
+
+// Ptr marks an option as explicitly supplied, including false and zero.
+func Ptr[Value any](value Value) *Value { return &value }
+
+type Backend string
+
+const (
+	Alacritty Backend = "alacritty"
+	Ghostty   Backend = "ghostty"
+	Rio       Backend = "rio"
+	XtermJS   Backend = "xtermjs"
+)
+
+type Shell string
+
+const (
+	Bash       Shell = "bash"
+	PowerShell Shell = "powershell"
+	Pwsh       Shell = "pwsh"
+	Cmd        Shell = "cmd"
+	Fish       Shell = "fish"
+	Zsh        Shell = "zsh"
+	Xonsh      Shell = "xonsh"
+	Elvish     Shell = "elvish"
+	Nushell    Shell = "nushell"
+)
+
+type UnderlineStyle string
+
+const (
+	UnderlineNone   UnderlineStyle = "none"
+	UnderlineSingle UnderlineStyle = "single"
+	UnderlineDouble UnderlineStyle = "double"
+	UnderlineCurly  UnderlineStyle = "curly"
+	UnderlineDotted UnderlineStyle = "dotted"
+	UnderlineDashed UnderlineStyle = "dashed"
+)
+
+type RecordingMode string
+
+const (
+	RecordingDisabled  RecordingMode = "disabled"
+	RecordingOnFailure RecordingMode = "on-failure"
+	RecordingAlways    RecordingMode = "always"
+)
+
+type RecordingFormat string
+
+const (
+	APNG RecordingFormat = "apng"
+	GIF  RecordingFormat = "gif"
+	MP4  RecordingFormat = "mp4"
+	Cast RecordingFormat = "cast"
+)
+
+type MouseButton string
+
+const (
+	Left   MouseButton = "left"
+	Middle MouseButton = "middle"
+	Right  MouseButton = "right"
+)
+
+type Direction string
+
+const (
+	Within Direction = "within"
+	After  Direction = "after"
+	Before Direction = "before"
+)
+
+type Whitespace string
+
+const (
+	Exact     Whitespace = "exact"
+	Normalize Whitespace = "normalize"
+)
+
+type Visibility string
+
+const (
+	Visible Visibility = "visible"
+	Hidden  Visibility = "hidden"
+)
+
+type ScrollDirection string
+
+const (
+	Up   ScrollDirection = "up"
+	Down ScrollDirection = "down"
+)
+
+// Timeouts leaves nil fields unspecified and preserves explicit zero durations.
+type Timeouts struct{ Text, Idle, Command, Exit, Ready *time.Duration }
+type EffectiveTimeouts struct{ Text, Idle, Command, Exit, Ready time.Duration }
+type Colors struct {
+	Foreground, Background, Cursor                                                                        string
+	Black, Red, Green, Yellow, Blue, Magenta, Cyan, White                                                 string
+	BrightBlack, BrightRed, BrightGreen, BrightYellow, BrightBlue, BrightMagenta, BrightCyan, BrightWhite string
+}
+type Profile struct {
+	Scrollback *uint32
+	Colors     Colors
+}
+type AutomaticRecording struct {
+	Mode      RecordingMode
+	Directory string
+}
+type ArtifactMode string
+
+const (
+	ArtifactSVG  ArtifactMode = "svg"
+	ArtifactText ArtifactMode = "text"
+	ArtifactNone ArtifactMode = "none"
+)
+
+type ArtifactOptions struct {
+	Dir       string
+	OnFailure ArtifactMode
+}
+type ClientOptions struct {
+	Backend   Backend
+	Profile   *Profile
+	Timeouts  Timeouts
+	Recording *AutomaticRecording
+	Artifacts *ArtifactOptions
+}
+type SpawnOptions struct {
+	Backend            Backend
+	Cols, Rows         *uint16
+	Cwd                string
+	Env                map[string]string
+	WaitReady, Restart *bool
+	Retries            uint32
+	Profile            *Profile
+	Timeouts           Timeouts
+}
+type OpenOptions struct {
+	SpawnOptions
+	Shell Shell
+}
+type WaitOptions struct{ Timeout *time.Duration }
+type TitleOptions struct {
+	Regex, Not bool
+	Timeout    *time.Duration
+}
+type ClipboardWaitOptions struct {
+	Text    *string
+	Regex   bool
+	Timeout *time.Duration
+}
+type TextOptions struct{ Full bool }
+type ScreenshotOptions struct {
+	Full bool
+	Zoom *float64
+}
+type RecordingOptions struct {
+	Format                     RecordingFormat
+	FPS                        *uint32
+	Speed, IdleTimeLimit, Zoom *float64
+}
+type SnapshotOptions struct {
+	Update, IncludeColors, IncludeTitle bool
+	Cwd                                 string
+}
+type SnapshotResult string
+
+const (
+	SnapshotPassed  SnapshotResult = "passed"
+	SnapshotWritten SnapshotResult = "written"
+	SnapshotUpdated SnapshotResult = "updated"
+)
+
+type OutputOptions struct{ Regex bool }
+type TextSelectorOptions struct {
+	Regex, Full bool
+	Whitespace  Whitespace
+	Direction   Direction
+}
+type StyleSelectorOptions struct {
+	Full      bool
+	Direction Direction
+}
+type TextStyle struct {
+	Foreground, Background                *string
+	Bold, Dim, Italic                     *bool
+	UnderlineStyle                        *UnderlineStyle
+	UnderlineColor                        *string
+	Inverse, Hidden, Strikethrough, Blink *bool
+}
+type LocatorWaitOptions struct {
+	State   Visibility
+	Timeout *time.Duration
+}
+type LocatorExpectOptions struct {
+	Not     bool
+	Timeout *time.Duration
+}
+type MouseButtonOptions struct {
+	Button           MouseButton
+	Alt, Ctrl, Shift bool
+}
+type MouseClickOptions struct {
+	MouseButtonOptions
+	X, Y   *uint16
+	OnText *string
+	Clicks *uint32
+}
+type LocatorClickOptions struct {
+	MouseButtonOptions
+	Clicks  *uint32
+	Timeout *time.Duration
+}
+type Cursor struct{ X, Y uint16 }
+type Size struct{ Cols, Rows uint16 }
+
+// Color is "default", a named or RGB color, or an indexed decimal color.
+type Color string
+type Cell struct {
+	X, Y                                                            uint16
+	Char                                                            string
+	FG, BG                                                          Color
+	Bold, Dim, Italic, Inverse, Invisible, Strike, Blink, Underline bool
+	UnderlineStyle                                                  UnderlineStyle
+	UnderlineColor                                                  Color
+}
+type BellEvent struct {
+	Sequence uint64
+	Elapsed  time.Duration
+}
+type TextPosition struct{ Row, Column uint32 }
+type TextSpan struct{ Row, Start, End uint32 }
+type TextMatch struct {
+	Text       string
+	Start, End TextPosition
+	Spans      []TextSpan
+}
+type OpenResult struct {
+	ShellPID  *uint32
+	Session   string
+	Ready     bool
+	Recording string
+}
+type State struct {
+	SessionShell            *string
+	Cols, Rows              uint16
+	Cursor                  Cursor
+	Title, Cwd, LastCommand *string
+	LastExit, Exited        *int32
+	Ready                   bool
+	BellCount               uint64
+	Timeouts                EffectiveTimeouts
+	Text                    string
+}
+type ErrorKind string
+
+const (
+	AssertionError ErrorKind = "assertion"
+	UsageError     ErrorKind = "usage"
+	NoSessionError ErrorKind = "no-session"
+	InternalError  ErrorKind = "internal"
+)
+
+type TerminalArtifact struct {
+	Text, Screenshot string
+	CaptureError     error
+}
+
+// Error retains the engine's category and diagnostic message for errors.As.
+type Error struct {
+	Kind      ErrorKind
+	Message   string
+	Operation string
+	Terminal  *TerminalArtifact
+}
+
+func (failure *Error) Error() string {
+	if failure.Operation != "" {
+		return failure.Operation + ": " + failure.Message
+	}
+	return failure.Message
+}


### PR DESCRIPTION
Adds Go bindings for terminal automation using the same in-process Rust engine as the JavaScript and Python bindings.

This PR contains the public Go API, its purego runtime bridge, and the Rust native adapter. Source checkouts build the adapter and select it explicitly with TUI_TEST_GO_NATIVE_LIBRARY.

- Provides typed clients, input controls, inspection, locators, waits, assertions, screenshots, and recording.
- Adds testing.TB helpers for session cleanup and failure artifacts.
- Keeps required runtime calls and memory ownership behind internal/native.
- Covers timeout inheritance, explicit zero overrides, shared-session preservation, and retry recovery.

The go-binding-automation follow-up contains the delivery layer: embedded native libraries, extraction and cache handling, generated C header and ABI layout verification, cbindgen, lint configuration, CI checks, release assembly, and published-module packaging. GitHub does not support first-class stacked PRs across forks, so that follow-up PR will be opened after this PR merges.