### PR TITLE
feat(terminal): report terminal mode state

### DIFF
--- a/bindings/js/native/index.d.ts
+++ b/bindings/js/native/index.d.ts
@@ -120,6 +120,9 @@ export type Color =
 export interface Cursor {
   x: number
   y: number
+  visible: boolean
+  shape: string
+  color: string
 }
 
 export interface EffectiveTimeouts {
@@ -296,6 +299,7 @@ export interface State {
   exited: number | null
   ready: boolean
   bell_count: number
+  modes: Record<string, boolean>
   timeouts: EffectiveTimeouts
   text: string
 }

--- a/bindings/js/native/index.d.ts
+++ b/bindings/js/native/index.d.ts
@@ -300,6 +300,7 @@ export interface State {
   ready: boolean
   bell_count: number
   modes: Record<string, boolean>
+  mouse_mode: string
   timeouts: EffectiveTimeouts
   text: string
 }

--- a/bindings/js/native/lib.rs
+++ b/bindings/js/native/lib.rs
@@ -253,6 +253,7 @@ pub struct State {
     #[napi(js_name = "bell_count")]
     pub bell_count: f64,
     pub modes: HashMap<String, bool>,
+    pub mouse_mode: String,
     pub timeouts: EffectiveTimeouts,
     pub text: String,
 }
@@ -272,6 +273,7 @@ impl From<CoreState> for State {
             ready: value.ready,
             bell_count: value.bell_count as f64,
             modes: value.modes.into_iter().collect(),
+            mouse_mode: value.mouse_mode,
             timeouts: value.timeouts.into(),
             text: value.text,
         }

--- a/bindings/js/native/lib.rs
+++ b/bindings/js/native/lib.rs
@@ -5,6 +5,8 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use napi::bindgen_prelude::{spawn_blocking, Buffer, Either};
 use napi::{Error, Result, Status};
+use std::collections::HashMap;
+
 use napi_derive::napi;
 use tui_test::profile::{Profile as CoreProfile, Rgb};
 use tui_test::shell::Shell as CoreShell;
@@ -164,6 +166,9 @@ impl From<CoreOpenResult> for OpenResult {
 pub struct Cursor {
     pub x: u16,
     pub y: u16,
+    pub visible: bool,
+    pub shape: String,
+    pub color: String,
 }
 
 impl From<CoreCursor> for Cursor {
@@ -171,6 +176,9 @@ impl From<CoreCursor> for Cursor {
         Self {
             x: value.x,
             y: value.y,
+            visible: value.visible,
+            shape: value.shape,
+            color: value.color,
         }
     }
 }
@@ -244,6 +252,7 @@ pub struct State {
     pub ready: bool,
     #[napi(js_name = "bell_count")]
     pub bell_count: f64,
+    pub modes: HashMap<String, bool>,
     pub timeouts: EffectiveTimeouts,
     pub text: String,
 }
@@ -262,6 +271,7 @@ impl From<CoreState> for State {
             exited: value.exited,
             ready: value.ready,
             bell_count: value.bell_count as f64,
+            modes: value.modes.into_iter().collect(),
             timeouts: value.timeouts.into(),
             text: value.text,
         }
@@ -947,7 +957,7 @@ impl NativeSession {
             "state",
             Operation::State,
             |result| match result {
-                OperationResult::State(value) => Ok(value.into()),
+                OperationResult::State(value) => Ok((*value).into()),
                 _ => Err(unexpected("state")),
             },
         )

--- a/bindings/js/native/lib.rs
+++ b/bindings/js/native/lib.rs
@@ -253,6 +253,7 @@ pub struct State {
     #[napi(js_name = "bell_count")]
     pub bell_count: f64,
     pub modes: HashMap<String, bool>,
+    #[napi(js_name = "mouse_mode")]
     pub mouse_mode: String,
     pub timeouts: EffectiveTimeouts,
     pub text: String,

--- a/bindings/python/native/src/lib.rs
+++ b/bindings/python/native/src/lib.rs
@@ -1662,7 +1662,7 @@ fn execute_open(name: &str, operation: Operation) -> Result<OpenResult, TuiTestE
 
 fn execute_state(name: &str, operation: Operation) -> Result<State, TuiTestError> {
     match global_registry().execute(name, operation)? {
-        OperationResult::State(value) => Ok(value),
+        OperationResult::State(value) => Ok(*value),
         _ => Err(unexpected_result("terminal state")),
     }
 }
@@ -1823,6 +1823,9 @@ fn cursor_dict(py: Python<'_>, cursor: Cursor) -> PyResult<Bound<'_, PyDict>> {
     let value = PyDict::new(py);
     value.set_item("x", cursor.x)?;
     value.set_item("y", cursor.y)?;
+    value.set_item("visible", cursor.visible)?;
+    value.set_item("shape", cursor.shape)?;
+    value.set_item("color", cursor.color)?;
     Ok(value)
 }
 
@@ -1861,6 +1864,11 @@ fn state_to_py(py: Python<'_>, value: State) -> PyResult<Py<PyAny>> {
     result.set_item("exited", value.exited)?;
     result.set_item("ready", value.ready)?;
     result.set_item("bell_count", value.bell_count)?;
+    let modes = PyDict::new(py);
+    for (name, enabled) in value.modes {
+        modes.set_item(name, enabled)?;
+    }
+    result.set_item("modes", modes)?;
     let timeouts = PyDict::new(py);
     timeouts.set_item("text", value.timeouts.text)?;
     timeouts.set_item("idle", value.timeouts.idle)?;

--- a/bindings/python/native/src/lib.rs
+++ b/bindings/python/native/src/lib.rs
@@ -1869,6 +1869,7 @@ fn state_to_py(py: Python<'_>, value: State) -> PyResult<Py<PyAny>> {
         modes.set_item(name, enabled)?;
     }
     result.set_item("modes", modes)?;
+    result.set_item("mouse_mode", value.mouse_mode)?;
     let timeouts = PyDict::new(py);
     timeouts.set_item("text", value.timeouts.text)?;
     timeouts.set_item("idle", value.timeouts.idle)?;

--- a/bindings/python/src/tui_test/types.py
+++ b/bindings/python/src/tui_test/types.py
@@ -160,6 +160,7 @@ class State:
     session_shell: Optional[str]
     bell_count: int = 0
     modes: Dict[str, bool] = field(default_factory=dict)
+    mouse_mode: str = "none"
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "State":
@@ -175,6 +176,7 @@ class State:
             ready=d.get("ready", False),
             bell_count=d.get("bell_count", 0),
             modes=d.get("modes", {}),
+            mouse_mode=d.get("mouse_mode", "none"),
             timeouts=Timeouts(**d["timeouts"]),
             text=d.get("text", ""),
             session_shell=d.get("session_shell"),

--- a/bindings/python/src/tui_test/types.py
+++ b/bindings/python/src/tui_test/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Literal, Optional, Union
 
 Color = Union[str, int]
@@ -148,7 +148,7 @@ class TextMatch:
 class State:
     cols: int
     rows: int
-    cursor: Dict[str, int]
+    cursor: Dict[str, Any]
     title: Optional[str]
     cwd: Optional[str]
     last_command: Optional[str]
@@ -159,6 +159,7 @@ class State:
     text: str
     session_shell: Optional[str]
     bell_count: int = 0
+    modes: Dict[str, bool] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "State":
@@ -173,6 +174,7 @@ class State:
             exited=d.get("exited"),
             ready=d.get("ready", False),
             bell_count=d.get("bell_count", 0),
+            modes=d.get("modes", {}),
             timeouts=Timeouts(**d["timeouts"]),
             text=d.get("text", ""),
             session_shell=d.get("session_shell"),

--- a/bindings/python/tests/test_integration.py
+++ b/bindings/python/tests/test_integration.py
@@ -659,7 +659,11 @@ class IntegrationTests(unittest.TestCase):
                 self.assertIsInstance(await su.get_cwd(), (str, type(None)))
                 self.assertEqual(await su.get_size(), {"cols": 90, "rows": 27})
                 cursor = await su.get_cursor()
-                self.assertEqual(set(cursor), {"x", "y"})
+                self.assertEqual(
+                    set(cursor), {"x", "y", "visible", "shape", "color"}
+                )
+                self.assertIsInstance(cursor["visible"], bool)
+                self.assertIn(cursor["shape"], {"block", "underline", "bar"})
                 cells = await su.cells(0, 0, 2, 1)
                 self.assertTrue(cells)
                 self.assertIsInstance(cells[0].fg, (str, int))

--- a/crates/tui-test-cli/src/cli.rs
+++ b/crates/tui-test-cli/src/cli.rs
@@ -969,6 +969,8 @@ pub enum GetArg {
     Title,
     /// Current clipboard.
     Clipboard,
+    /// Every terminal mode and whether it is set.
+    Modes,
     /// Cumulative terminal bell count.
     Bells,
     /// Recorded terminal bell events (sequence + elapsed time).
@@ -1401,6 +1403,38 @@ pub enum ExpectCmd {
         regex: bool,
     },
     /// Wait until the cumulative terminal bell count reaches this value.
+    /// Assert a terminal mode is set.
+    Mode {
+        /// Mode name, as reported by `get modes`.
+        name: String,
+        /// Require the mode to be off instead of on.
+        #[arg(long)]
+        off: bool,
+        /// Timeout in milliseconds.
+        #[arg(long, value_name = "MS")]
+        timeout: Option<u64>,
+    },
+    /// Assert the cursor's position, visibility, or shape.
+    Cursor {
+        /// Require the cursor to be drawn.
+        #[arg(long, conflicts_with = "hidden")]
+        visible: bool,
+        /// Require the cursor to be hidden.
+        #[arg(long)]
+        hidden: bool,
+        /// Required shape: block, underline, or bar.
+        #[arg(long)]
+        shape: Option<String>,
+        /// Required column.
+        #[arg(long)]
+        x: Option<u16>,
+        /// Required row.
+        #[arg(long)]
+        y: Option<u16>,
+        /// Timeout in milliseconds.
+        #[arg(long, value_name = "MS")]
+        timeout: Option<u64>,
+    },
     Bell {
         /// Minimum cumulative bell count.
         count: u64,

--- a/crates/tui-test-cli/src/main.rs
+++ b/crates/tui-test-cli/src/main.rs
@@ -340,6 +340,7 @@ fn map_field(field: GetArg) -> GetField {
         GetArg::ExitCode => GetField::ExitCode,
         GetArg::Cwd => GetField::Cwd,
         GetArg::Cursor => GetField::Cursor,
+        GetArg::Modes => GetField::Modes,
         GetArg::Size => GetField::Size,
         GetArg::Title => GetField::Title,
         GetArg::Clipboard => GetField::Clipboard,
@@ -588,6 +589,32 @@ fn map_expect(what: ExpectCmd) -> Request {
             timeout_ms: timeout,
         },
         ExpectCmd::Output { text, regex } => Request::ExpectOutput { text, regex },
+        ExpectCmd::Mode { name, off, timeout } => Request::ExpectMode {
+            mode: name,
+            enabled: !off,
+            timeout_ms: timeout,
+        },
+        ExpectCmd::Cursor {
+            visible,
+            hidden,
+            shape,
+            x,
+            y,
+            timeout,
+        } => Request::ExpectCursor {
+            // `--visible` and `--hidden` are separate flags rather than one
+            // optional boolean so that naming neither leaves visibility
+            // unchecked, which is what a caller asserting only a shape wants.
+            visible: match (visible, hidden) {
+                (true, _) => Some(true),
+                (_, true) => Some(false),
+                _ => None,
+            },
+            shape,
+            x,
+            y,
+            timeout_ms: timeout,
+        },
         ExpectCmd::Bell { count, timeout } => Request::ExpectBellCount {
             count,
             timeout_ms: timeout,

--- a/crates/tui-test-cli/src/protocol.rs
+++ b/crates/tui-test-cli/src/protocol.rs
@@ -148,6 +148,18 @@ pub enum Request {
         text: String,
         regex: bool,
     },
+    ExpectMode {
+        mode: String,
+        enabled: bool,
+        timeout_ms: Option<u64>,
+    },
+    ExpectCursor {
+        visible: Option<bool>,
+        shape: Option<String>,
+        x: Option<u16>,
+        y: Option<u16>,
+        timeout_ms: Option<u64>,
+    },
     ExpectBellCount {
         count: u64,
         #[serde(default)]
@@ -261,6 +273,7 @@ impl Request {
                 GetField::ExitCode => Operation::GetExitCode,
                 GetField::Cwd => Operation::GetCwd,
                 GetField::Cursor => Operation::GetCursor,
+                GetField::Modes => Operation::GetModes,
                 GetField::Size => Operation::GetSize,
                 GetField::Title => Operation::GetTitle,
                 GetField::Clipboard => Operation::GetClipboard,
@@ -355,6 +368,28 @@ impl Request {
                 Ok(Operation::ExpectExitCode { code, timeout_ms })
             }
             Request::ExpectOutput { text, regex } => Ok(Operation::ExpectOutput { text, regex }),
+            Request::ExpectMode {
+                mode,
+                enabled,
+                timeout_ms,
+            } => Ok(Operation::ExpectMode {
+                mode,
+                enabled,
+                timeout_ms,
+            }),
+            Request::ExpectCursor {
+                visible,
+                shape,
+                x,
+                y,
+                timeout_ms,
+            } => Ok(Operation::ExpectCursor {
+                visible,
+                shape,
+                x,
+                y,
+                timeout_ms,
+            }),
             Request::ExpectBellCount { count, timeout_ms } => {
                 Ok(Operation::ExpectBellCount { count, timeout_ms })
             }
@@ -410,6 +445,7 @@ pub enum GetField {
     ExitCode,
     Cwd,
     Cursor,
+    Modes,
     Size,
     Title,
     Clipboard,
@@ -500,6 +536,7 @@ fn operation_data(result: OperationResult) -> Result<Option<serde_json::Value>, 
         OperationResult::Title(value) => Ok(json!({ "value": value })),
         OperationResult::Clipboard(value) => Ok(json!({ "value": value })),
         OperationResult::Cursor(value) => Ok(json!({ "value": value })),
+        OperationResult::Modes(value) => Ok(json!({ "modes": value })),
         OperationResult::Size(value) => Ok(json!({ "value": value })),
         OperationResult::BellCount(value) => Ok(json!({ "value": value })),
         OperationResult::BellEvents(value) => Ok(json!({ "value": value })),

--- a/crates/tui-test/assets/xtermjs/shim.js
+++ b/crates/tui-test/assets/xtermjs/shim.js
@@ -334,7 +334,27 @@ globalThis.__boot = function (cols, rows, scrollback, base) {
       var s = term._core.coreService.decPrivateModes.cursorStyle;
       return s === undefined ? 'block' : String(s);
     },
-    bracketedPaste: function () { return term.modes.bracketedPasteMode; },
+    // Terminal modes, keyed by the neutral names the Rust side uses.
+    //
+    // `term.modes` is a fixed set rather than a "read mode N" call, which is
+    // why the Rust vocabulary is a closed enum: these are the ones every
+    // backend can answer. The alternate screen is the exception, absent from
+    // `modes` but readable from the active buffer, which reports `alternate`
+    // exactly while `?1049` or `?47` is in effect.
+    mode: function (name) {
+      var m = term.modes;
+      switch (name) {
+        case 'application_cursor_keys': return m.applicationCursorKeysMode ? 1 : 0;
+        case 'application_keypad': return m.applicationKeypadMode ? 1 : 0;
+        case 'origin': return m.originMode ? 1 : 0;
+        case 'wraparound': return m.wraparoundMode ? 1 : 0;
+        case 'insert': return m.insertMode ? 1 : 0;
+        case 'focus_events': return m.sendFocusMode ? 1 : 0;
+        case 'bracketed_paste': return m.bracketedPasteMode ? 1 : 0;
+        case 'alternate_screen': return term.buffer.active.type === 'alternate' ? 1 : 0;
+        default: return 0;
+      }
+    },
 
     // A color a program set, or -1 when it has not touched this slot and the
     // profile still decides. Kept as one call per slot: only a handful are

--- a/crates/tui-test/src/api.rs
+++ b/crates/tui-test/src/api.rs
@@ -863,6 +863,10 @@ pub struct State {
     /// independent switches: `CSI ?1002 h` replaces `CSI ?1000 h` rather than
     /// joining it, so reporting it as booleans would say two are on when the
     /// terminal only honors the last.
+    ///
+    /// Independent of how the child asked for the reports to be encoded.
+    /// `CSI ?1000 h` on its own is `click`, whether or not `CSI ?1006 h`
+    /// followed it to ask for SGR coordinates.
     pub mouse_mode: String,
     pub timeouts: EffectiveTimeouts,
     pub text: String,

--- a/crates/tui-test/src/api.rs
+++ b/crates/tui-test/src/api.rs
@@ -791,7 +791,7 @@ pub struct Cursor {
     pub visible: bool,
     /// `block`, `underline`, or `bar` (`DECSCUSR`).
     pub shape: String,
-    /// The cursor colour as `#rrggbb`, after any `OSC 12` a program sent.
+    /// The cursor color as `#rrggbb`, after any `OSC 12` a program sent.
     pub color: String,
 }
 
@@ -862,7 +862,7 @@ pub struct State {
     /// Separate from `modes` because mouse tracking is not a set of
     /// independent switches: `CSI ?1002 h` replaces `CSI ?1000 h` rather than
     /// joining it, so reporting it as booleans would say two are on when the
-    /// terminal only honours the last.
+    /// terminal only honors the last.
     pub mouse_mode: String,
     pub timeouts: EffectiveTimeouts,
     pub text: String,

--- a/crates/tui-test/src/api.rs
+++ b/crates/tui-test/src/api.rs
@@ -857,6 +857,13 @@ pub struct State {
     /// A map rather than a list, so a reader can tell "off" from "this build
     /// does not know that mode" and every key is always present.
     pub modes: BTreeMap<String, bool>,
+    /// Mouse tracking level: `none`, `click`, `drag`, or `motion`.
+    ///
+    /// Separate from `modes` because mouse tracking is not a set of
+    /// independent switches: `CSI ?1002 h` replaces `CSI ?1000 h` rather than
+    /// joining it, so reporting it as booleans would say two are on when the
+    /// terminal only honours the last.
+    pub mouse_mode: String,
     pub timeouts: EffectiveTimeouts,
     pub text: String,
 }

--- a/crates/tui-test/src/api.rs
+++ b/crates/tui-test/src/api.rs
@@ -537,6 +537,7 @@ pub enum Operation {
     GetExitCode,
     GetCwd,
     GetCursor,
+    GetModes,
     GetSize,
     GetTitle,
     GetClipboard,
@@ -618,6 +619,20 @@ pub enum Operation {
         code: i32,
         timeout_ms: Option<u64>,
     },
+    /// Wait for a terminal mode to reach `enabled`.
+    ExpectMode {
+        mode: String,
+        enabled: bool,
+        timeout_ms: Option<u64>,
+    },
+    /// Wait for the cursor to match every property the caller named.
+    ExpectCursor {
+        visible: Option<bool>,
+        shape: Option<String>,
+        x: Option<u16>,
+        y: Option<u16>,
+        timeout_ms: Option<u64>,
+    },
     ExpectOutput {
         text: String,
         regex: bool,
@@ -666,7 +681,9 @@ impl Operation {
 pub enum OperationResult {
     Unit,
     Open(OpenResult),
-    State(State),
+    /// Boxed because it is much larger than every other variant, and a
+    /// `Result` of this enum is returned from every operation.
+    State(Box<State>),
     Text(String),
     PackedScreen(PackedScreen),
     Cells(Vec<Cell>),
@@ -678,6 +695,7 @@ pub enum OperationResult {
     Title(Option<String>),
     Clipboard(String),
     Cursor(Cursor),
+    Modes(BTreeMap<String, bool>),
     Size(Size),
     BellCount(u64),
     BellEvents(Vec<BellEvent>),
@@ -765,10 +783,16 @@ pub struct OpenResult {
     pub recording: String,
 }
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Cursor {
     pub x: u16,
     pub y: u16,
+    /// Whether the cursor is drawn (`DECTCEM`).
+    pub visible: bool,
+    /// `block`, `underline`, or `bar` (`DECSCUSR`).
+    pub shape: String,
+    /// The cursor colour as `#rrggbb`, after any `OSC 12` a program sent.
+    pub color: String,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]

--- a/crates/tui-test/src/api.rs
+++ b/crates/tui-test/src/api.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::path::PathBuf;
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::shell::Shell;
@@ -826,6 +828,11 @@ pub struct State {
     pub exited: Option<i32>,
     pub ready: bool,
     pub bell_count: u64,
+    /// Terminal modes the child has turned on, by name.
+    ///
+    /// A map rather than a list, so a reader can tell "off" from "this build
+    /// does not know that mode" and every key is always present.
+    pub modes: BTreeMap<String, bool>,
     pub timeouts: EffectiveTimeouts,
     pub text: String,
 }

--- a/crates/tui-test/src/engine.rs
+++ b/crates/tui-test/src/engine.rs
@@ -401,7 +401,7 @@ impl Engine {
                 size: state.emu.size(),
                 keyboard_mode: state.emu.keyboard_mode(),
                 bracketed_paste: state.emu.mode(TerminalMode::BracketedPaste),
-                mouse_mode: state.mouse_mode.mode(),
+                mouse_mode: state.mouse_mode.relayable(),
                 exited: state.exited,
                 shell: target.shell,
             }
@@ -418,7 +418,7 @@ impl Engine {
                 .state
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            (state.mouse_mode.mode() != MouseMode::None).then(|| state.emu.size())
+            (state.mouse_mode.relayable() != MouseMode::None).then(|| state.emu.size())
         })
     }
 

--- a/crates/tui-test/src/engine.rs
+++ b/crates/tui-test/src/engine.rs
@@ -17,7 +17,9 @@ use crate::input::{keys, mouse};
 use crate::logger::Logger;
 use crate::session::{Session as TerminalSession, TermState, TextHighlight};
 use crate::terminal::cell::{rows_to_strings, Attrs, Color, EmuCell};
-use crate::terminal::emu::{ClipboardType, Emulator, KeyboardMode, MouseMode};
+use crate::terminal::emu::{
+    ClipboardType, CursorShape, Emulator, KeyboardMode, MouseMode, TerminalMode,
+};
 use crate::terminal::locator::{self, Pattern};
 
 pub struct Engine {
@@ -741,7 +743,7 @@ fn dispatch(
     operation: Operation,
 ) -> Result<OperationResult, TuiTestError> {
     match operation {
-        Operation::State => Ok(OperationResult::State(state(session))),
+        Operation::State => Ok(OperationResult::State(Box::new(state(session)))),
         Operation::Text { full } => Ok(OperationResult::Text(text_of(&grid(session, full)))),
         Operation::PackedScreen { full } => {
             Ok(OperationResult::PackedScreen(packed_screen(session, full)))
@@ -785,13 +787,48 @@ fn dispatch(
         Operation::GetTitle => Ok(OperationResult::Title(title_of(session))),
         Operation::GetClipboard => Ok(OperationResult::Clipboard(get_clipboard(session)?)),
         Operation::GetCursor => {
-            let (x, y) = session
+            let state = session
                 .state
                 .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .emu
-                .cursor();
-            Ok(OperationResult::Cursor(Cursor { x, y }))
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            Ok(OperationResult::Cursor(cursor_model(state.emu.as_ref())))
+        }
+        Operation::GetModes => {
+            let state = session
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            Ok(OperationResult::Modes(modes_of(state.emu.as_ref())))
+        }
+        Operation::ExpectMode {
+            mode,
+            enabled,
+            timeout_ms,
+        } => {
+            expect_mode(
+                session,
+                &mode,
+                enabled,
+                timeout_ms.unwrap_or_else(|| session.timeout_for(config::TimeoutClass::Text)),
+            )?;
+            Ok(OperationResult::Unit)
+        }
+        Operation::ExpectCursor {
+            visible,
+            shape,
+            x,
+            y,
+            timeout_ms,
+        } => {
+            expect_cursor(
+                session,
+                visible,
+                shape.as_deref(),
+                x,
+                y,
+                timeout_ms.unwrap_or_else(|| session.timeout_for(config::TimeoutClass::Text)),
+            )?;
+            Ok(OperationResult::Unit)
         }
         Operation::GetSize => {
             let (cols, rows) = session
@@ -1019,14 +1056,13 @@ fn state(session: &TerminalSession) -> crate::api::State {
         .state
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let (x, y) = state.emu.cursor();
     let (cols, rows) = state.emu.size();
     let bells = session.bells.snapshot();
     crate::api::State {
         session_shell: session.shell.map(|value| value.as_str().to_string()),
         cols,
         rows,
-        cursor: Cursor { x, y },
+        cursor: cursor_model(state.emu.as_ref()),
         title: state.emu.title(),
         cwd: state.tracker.cwd().map(str::to_string),
         last_command: state.tracker.last_command().map(str::to_string),
@@ -1103,6 +1139,125 @@ fn cell_model(x: u16, y: u16, cell: &EmuCell) -> Cell {
             .and_then(|link| link.id.as_deref())
             .unwrap_or_default()
             .to_string(),
+    }
+}
+
+/// Resolve a mode name, so an unknown one is a usage error naming the set
+/// rather than a silent `false`.
+fn parse_mode(name: &str) -> Result<TerminalMode, TuiTestError> {
+    TerminalMode::ALL
+        .into_iter()
+        .find(|mode| mode.name() == name)
+        .ok_or_else(|| {
+            let known = TerminalMode::ALL
+                .iter()
+                .map(|mode| mode.name())
+                .collect::<Vec<_>>()
+                .join(", ");
+            TuiTestError::usage(format!(
+                "unknown terminal mode '{name}'; expected one of: {known}"
+            ))
+        })
+}
+
+fn modes_of(emu: &dyn Emulator) -> std::collections::BTreeMap<String, bool> {
+    TerminalMode::ALL
+        .into_iter()
+        .map(|mode| (mode.name().to_string(), emu.mode(mode)))
+        .collect()
+}
+
+fn expect_mode(
+    session: &TerminalSession,
+    name: &str,
+    enabled: bool,
+    timeout_ms: u64,
+) -> Result<(), TuiTestError> {
+    let mode = parse_mode(name)?;
+    let reached = |session: &TerminalSession| {
+        session
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .emu
+            .mode(mode)
+            == enabled
+    };
+    let mut matched = false;
+    poll_until(
+        || {
+            matched = reached(session);
+            matched || session_stopped(session)
+        },
+        timeout_ms,
+    );
+    if matched {
+        return Ok(());
+    }
+    Err(TuiTestError::assertion(format!(
+        "{} did not turn {} within {timeout_ms}ms",
+        mode.name(),
+        if enabled { "on" } else { "off" }
+    )))
+}
+
+fn expect_cursor(
+    session: &TerminalSession,
+    visible: Option<bool>,
+    shape: Option<&str>,
+    x: Option<u16>,
+    y: Option<u16>,
+    timeout_ms: u64,
+) -> Result<(), TuiTestError> {
+    if let Some(shape) = shape {
+        if CursorShape::parse(shape).is_none() {
+            return Err(TuiTestError::usage(format!(
+                "unknown cursor shape '{shape}'; expected block, underline, or bar"
+            )));
+        }
+    }
+    let mut last = None;
+    let mut matched = false;
+    poll_until(
+        || {
+            let cursor = {
+                let state = session
+                    .state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                cursor_model(state.emu.as_ref())
+            };
+            matched = visible.is_none_or(|want| want == cursor.visible)
+                && shape.is_none_or(|want| want == cursor.shape)
+                && x.is_none_or(|want| want == cursor.x)
+                && y.is_none_or(|want| want == cursor.y);
+            last = Some(cursor);
+            matched || session_stopped(session)
+        },
+        timeout_ms,
+    );
+    if matched {
+        return Ok(());
+    }
+    let cursor = last.expect("the cursor is read at least once");
+    Err(TuiTestError::assertion(format!(
+        "cursor did not match within {timeout_ms}ms; it is at {},{}, {}, shape {}",
+        cursor.x,
+        cursor.y,
+        if cursor.visible { "visible" } else { "hidden" },
+        cursor.shape
+    )))
+}
+
+/// The cursor as a caller sees it: where it is, and how it is drawn.
+fn cursor_model(emu: &dyn Emulator) -> Cursor {
+    let (x, y) = emu.cursor();
+    Cursor {
+        x,
+        y,
+        visible: emu.cursor_visible(),
+        shape: emu.cursor_shape().name().to_string(),
+        color: emu.color(crate::profile::ColorSlot::Cursor).to_hex(),
     }
 }
 

--- a/crates/tui-test/src/engine.rs
+++ b/crates/tui-test/src/engine.rs
@@ -1034,6 +1034,10 @@ fn state(session: &TerminalSession) -> crate::api::State {
         exited: state.exited,
         ready: state.tracker.is_ready(),
         bell_count: bells.count,
+        modes: crate::terminal::emu::TerminalMode::ALL
+            .into_iter()
+            .map(|mode| (mode.name().to_string(), state.emu.mode(mode)))
+            .collect(),
         timeouts: effective_timeouts(session),
         text: text_of(&state.emu.viewable_rows()),
     }

--- a/crates/tui-test/src/engine.rs
+++ b/crates/tui-test/src/engine.rs
@@ -400,7 +400,7 @@ impl Engine {
                 cursor: state.emu.cursor(),
                 size: state.emu.size(),
                 keyboard_mode: state.emu.keyboard_mode(),
-                bracketed_paste: state.emu.bracketed_paste_mode(),
+                bracketed_paste: state.emu.mode(TerminalMode::BracketedPaste),
                 mouse_mode: state.mouse_mode.mode(),
                 exited: state.exited,
                 shell: target.shell,
@@ -1074,6 +1074,7 @@ fn state(session: &TerminalSession) -> crate::api::State {
             .into_iter()
             .map(|mode| (mode.name().to_string(), state.emu.mode(mode)))
             .collect(),
+        mouse_mode: state.mouse_mode.mode().name().to_string(),
         timeouts: effective_timeouts(session),
         text: text_of(&state.emu.viewable_rows()),
     }

--- a/crates/tui-test/src/terminal/alacritty.rs
+++ b/crates/tui-test/src/terminal/alacritty.rs
@@ -556,7 +556,10 @@ impl Emulator for AlacrittyEmu {
 mod tests {
     use super::*;
 
-    crate::emulator_conformance_tests!(|c, r, p| Box::new(AlacrittyEmu::new(c, r, p)));
+    crate::emulator_conformance_tests!(
+        |c, r, p| Box::new(AlacrittyEmu::new(c, r, p)),
+        &[crate::terminal::conformance::Divergence::NoLegacyAlternateScreen]
+    );
 
     #[test]
     fn multiple_bells_in_one_chunk_are_counted_individually() {

--- a/crates/tui-test/src/terminal/alacritty.rs
+++ b/crates/tui-test/src/terminal/alacritty.rs
@@ -679,15 +679,6 @@ mod tests {
     }
 
     #[test]
-    fn tracks_bracketed_paste_mode() {
-        let mut emu = AlacrittyEmu::new(10, 2, &Profile::default());
-        emu.process(b"\x1b[?2004h");
-        assert!(emu.bracketed_paste_mode());
-        emu.process(b"\x1b[?2004l");
-        assert!(!emu.bracketed_paste_mode());
-    }
-
-    #[test]
     fn main_and_alternate_screens_keep_independent_keyboard_modes() {
         let mut emu = AlacrittyEmu::new(10, 2, &Profile::default());
 

--- a/crates/tui-test/src/terminal/alacritty.rs
+++ b/crates/tui-test/src/terminal/alacritty.rs
@@ -27,7 +27,7 @@ use crate::terminal::cell::{
     Attrs, Color, EmuCell, Hyperlink, LinkCache, UnderlineStyle, CONTINUATION,
 };
 use crate::terminal::emu::{
-    Clipboard, ClipboardType, ClipboardValidator, CursorShape, Emulator, KeyboardMode,
+    Clipboard, ClipboardType, ClipboardValidator, CursorShape, Emulator, KeyboardMode, TerminalMode,
 };
 
 fn clipboard_type(clipboard: AlacClipboardType) -> ClipboardType {
@@ -455,8 +455,18 @@ impl Emulator for AlacrittyEmu {
         keyboard_mode
     }
 
-    fn bracketed_paste_mode(&self) -> bool {
-        self.term.mode().contains(TermMode::BRACKETED_PASTE)
+    fn mode(&self, mode: TerminalMode) -> bool {
+        let flag = match mode {
+            TerminalMode::ApplicationCursorKeys => TermMode::APP_CURSOR,
+            TerminalMode::ApplicationKeypad => TermMode::APP_KEYPAD,
+            TerminalMode::Origin => TermMode::ORIGIN,
+            TerminalMode::Wraparound => TermMode::LINE_WRAP,
+            TerminalMode::Insert => TermMode::INSERT,
+            TerminalMode::FocusEvents => TermMode::FOCUS_IN_OUT,
+            TerminalMode::BracketedPaste => TermMode::BRACKETED_PASTE,
+            TerminalMode::AlternateScreen => TermMode::ALT_SCREEN,
+        };
+        self.term.mode().contains(flag)
     }
 
     fn title(&self) -> Option<String> {

--- a/crates/tui-test/src/terminal/alacritty.rs
+++ b/crates/tui-test/src/terminal/alacritty.rs
@@ -465,6 +465,9 @@ impl Emulator for AlacrittyEmu {
             TerminalMode::FocusEvents => TermMode::FOCUS_IN_OUT,
             TerminalMode::BracketedPaste => TermMode::BRACKETED_PASTE,
             TerminalMode::AlternateScreen => TermMode::ALT_SCREEN,
+            // `Hidden` is a shape alacritty uses for a cursor it will not
+            // draw, so this flag means the same thing as `DECTCEM`.
+            TerminalMode::CursorVisible => TermMode::SHOW_CURSOR,
         };
         self.term.mode().contains(flag)
     }

--- a/crates/tui-test/src/terminal/conformance.rs
+++ b/crates/tui-test/src/terminal/conformance.rs
@@ -1674,17 +1674,19 @@ macro_rules! emulator_conformance_tests {
             }
         }
 
-        /// Every way onto the alternate screen is reported as being on it.
+        /// Every way onto the alternate screen is reported as being on it,
+        /// and leaving it is reported too.
         ///
         /// `?1049` is what a full-screen program sends, and every backend
         /// honors it. `?47` and `?1047` are the older spellings, without the
         /// cursor save `?1049` bundles in; alacritty and rio ignore them
         /// outright.
         ///
-        /// What must hold everywhere is that the flag and the screen agree: a
-        /// backend that switches buffers has to say so. Ghostty tracks each
-        /// spelling under its own mode, so reading only `?1049` reported the
-        /// primary screen while the alternate one was showing.
+        /// What must hold everywhere is that the flag and the screen agree, in
+        /// both directions. The three spellings share one screen but have
+        /// independent mode bits, so on ghostty `?47h` then `?1049l` leaves
+        /// the `?47` bit set with the primary screen showing — reading mode
+        /// bits answers the wrong question, in one direction or the other.
         #[test]
         fn conformance_alt_screen_flag_follows_the_screen() {
             use $crate::terminal::emu::TerminalMode;
@@ -1699,10 +1701,11 @@ macro_rules! emulator_conformance_tests {
                 let mut e = conformance_emu(10, 3, 100);
                 e.process(b"primary");
                 e.process(sequence);
-                let text = conformance_text(&e.viewable_rows());
-                let showing_alt = !text.iter().any(|r| r.contains("primary"));
                 let name = String::from_utf8_lossy(sequence).to_string();
 
+                let showing_alt = !conformance_text(&e.viewable_rows())
+                    .iter()
+                    .any(|r| r.contains("primary"));
                 assert_eq!(
                     e.mode(TerminalMode::AlternateScreen),
                     showing_alt,
@@ -1713,6 +1716,20 @@ macro_rules! emulator_conformance_tests {
                 } else {
                     assert!(!showing_alt, "{name} is ignored by this backend");
                 }
+
+                // Leaving has to be reported as leaving, whichever spelling
+                // got there: `?1049l` is what a program sends on the way out.
+                e.process(b"\x1b[?1049l");
+                assert!(
+                    conformance_text(&e.viewable_rows())
+                        .iter()
+                        .any(|r| r.contains("primary")),
+                    "{name}: ?1049l restores the primary screen"
+                );
+                assert!(
+                    !e.mode(TerminalMode::AlternateScreen),
+                    "{name}: and alternate_screen says so"
+                );
             }
         }
 

--- a/crates/tui-test/src/terminal/conformance.rs
+++ b/crates/tui-test/src/terminal/conformance.rs
@@ -474,6 +474,55 @@ macro_rules! emulator_conformance_tests {
             );
         }
 
+        /// Every mode in the vocabulary turns on and off on every backend.
+        ///
+        /// This case is the reason the vocabulary is a closed set: a mode
+        /// earns a variant by passing here on all four backends, so the enum
+        /// is a claim this test keeps honest rather than a wish list.
+        #[test]
+        fn conformance_terminal_modes_turn_on_and_off() {
+            use $crate::terminal::emu::TerminalMode;
+            for mode in TerminalMode::ALL {
+                let mut e = conformance_emu(20, 4, 100);
+                assert_eq!(
+                    e.mode(mode),
+                    mode.default_enabled(),
+                    "{} starts at its documented default",
+                    mode.name()
+                );
+
+                e.process(mode.set_sequence());
+                assert!(e.mode(mode), "{} did not turn on", mode.name());
+
+                e.process(mode.reset_sequence());
+                assert!(!e.mode(mode), "{} did not turn off", mode.name());
+            }
+        }
+
+        /// Setting one mode leaves the others alone, so a backend that mapped
+        /// two of them onto the same flag fails here rather than silently
+        /// reporting one when a test asked about the other.
+        #[test]
+        fn conformance_terminal_modes_are_independent() {
+            use $crate::terminal::emu::TerminalMode;
+            for mode in TerminalMode::ALL {
+                let mut e = conformance_emu(20, 4, 100);
+                e.process(mode.set_sequence());
+                for other in TerminalMode::ALL {
+                    if other == mode {
+                        continue;
+                    }
+                    assert_eq!(
+                        e.mode(other),
+                        other.default_enabled(),
+                        "setting {} also changed {}",
+                        mode.name(),
+                        other.name()
+                    );
+                }
+            }
+        }
+
         /// Resetting the underline color must not be confusable with setting
         /// it to white.
         ///

--- a/crates/tui-test/src/terminal/conformance.rs
+++ b/crates/tui-test/src/terminal/conformance.rs
@@ -48,6 +48,13 @@ pub enum Divergence {
     /// It belongs here rather than in a profile default because it is the
     /// emulator's own limit, not a setting.
     NoKittyKeyboard,
+    /// `RIS` does not put `DECTCEM` back, so a hidden cursor stays hidden
+    /// through a reset that restores every other mode.
+    ///
+    /// Verified rather than inferred: on the same emulator `RIS` does clear
+    /// bracketed paste, so this is the terminal's own state and not the
+    /// mapping onto it.
+    RisDoesNotResetCursorVisibility,
 }
 
 /// Generates the conformance tests for one backend. `$make` builds a boxed
@@ -107,17 +114,54 @@ macro_rules! emulator_conformance_tests {
                 .contains(&$crate::terminal::conformance::Divergence::ClipboardUnsupported)
         }
 
+        /// A mode sequence still lands when a PTY read splits it, which is
+        /// where an emulator that scanned for whole sequences would fail.
+        /// Split one byte before the final letter, the last place the parser
+        /// can still be holding parameters.
         #[test]
-        fn conformance_bracketed_paste_mode_tracks_enable_disable_and_reset() {
-            let mut e = conformance_emu(10, 4, 100);
-            assert!(!e.bracketed_paste_mode());
-            e.process(b"\x1b[?20");
-            e.process(b"04h");
-            assert!(e.bracketed_paste_mode());
-            e.process(b"\x1b[?2004l");
-            assert!(!e.bracketed_paste_mode());
-            e.process(b"\x1b[?2004h\x1bc");
-            assert!(!e.bracketed_paste_mode());
+        fn conformance_terminal_modes_survive_a_split_read() {
+            use $crate::terminal::emu::TerminalMode;
+            for mode in TerminalMode::ALL {
+                let set = mode.set_sequence();
+                let (head, tail) = set.split_at(set.len() - 1);
+                let mut e = conformance_emu(20, 4, 100);
+                e.process(head);
+                e.process(tail);
+                assert!(e.mode(mode), "{} lost across a split read", mode.name());
+            }
+        }
+
+        /// `RIS` puts every mode back to its default, which is how a program
+        /// that leaves the terminal in a strange state is recovered from.
+        #[test]
+        fn conformance_ris_resets_every_terminal_mode() {
+            use $crate::terminal::emu::TerminalMode;
+            for mode in TerminalMode::ALL {
+                let mut e = conformance_emu(20, 4, 100);
+                // Drive it away from its default in whichever direction that is.
+                let away = if mode.default_enabled() {
+                    mode.reset_sequence()
+                } else {
+                    mode.set_sequence()
+                };
+                e.process(away);
+                assert_eq!(e.mode(mode), !mode.default_enabled());
+
+                e.process(b"\x1bc");
+                if mode == TerminalMode::CursorVisible
+                    && CONFORMANCE_DIVERGENCES.contains(
+                        &$crate::terminal::conformance::Divergence::RisDoesNotResetCursorVisibility,
+                    )
+                {
+                    continue;
+                }
+                assert_eq!(
+                    e.mode(mode),
+                    mode.default_enabled(),
+                    "RIS did not restore {}",
+                    mode.name()
+                );
+            }
         }
 
         /// The grid is always exactly `rows` x `cols`, regardless of content.

--- a/crates/tui-test/src/terminal/conformance.rs
+++ b/crates/tui-test/src/terminal/conformance.rs
@@ -55,6 +55,18 @@ pub enum Divergence {
     /// bracketed paste, so this is the terminal's own state and not the
     /// mapping onto it.
     RisDoesNotResetCursorVisibility,
+
+    /// `CSI ?47 h` and `CSI ?1047 h` are ignored, so only `CSI ?1049 h`
+    /// reaches the alternate screen.
+    ///
+    /// The two older sequences predate the cursor save that `?1049` bundles
+    /// in. A backend that drops them stays on the primary screen and reports
+    /// `alternate_screen` false, which is an honest account of what it did —
+    /// the divergence is that it did nothing at all.
+    ///
+    /// Nothing in practice depends on it: every terminal here honors `?1049`,
+    /// and that is what a full-screen program sends.
+    NoLegacyAlternateScreen,
 }
 
 /// Generates the conformance tests for one backend. `$make` builds a boxed
@@ -1176,6 +1188,35 @@ macro_rules! emulator_conformance_tests {
             }
         }
 
+        /// Hiding the cursor does not change its shape.
+        ///
+        /// `DECTCEM` and `DECSCUSR` are separate: one says whether the cursor
+        /// is drawn, the other says what it looks like when it is. A program
+        /// that hides the cursor for a redraw and shows it again has not asked
+        /// for a different shape, so the shape it chose has to survive.
+        #[test]
+        fn conformance_hiding_the_cursor_keeps_its_shape() {
+            use $crate::terminal::emu::CursorShape;
+            let mut e = conformance_emu(10, 3, 100);
+            e.process(b"\x1b[5 q");
+            assert_eq!(e.cursor_shape(), CursorShape::Bar);
+
+            e.process(b"\x1b[?25l");
+            assert!(!e.mode($crate::terminal::emu::TerminalMode::CursorVisible));
+            assert_eq!(
+                e.cursor_shape(),
+                CursorShape::Bar,
+                "a hidden cursor still has the shape it was given"
+            );
+
+            e.process(b"\x1b[?25h");
+            assert_eq!(
+                e.cursor_shape(),
+                CursorShape::Bar,
+                "and showing it again does not reset the shape"
+            );
+        }
+
         /// A color query is answered with the session's configured color.
         ///
         /// Programs query the background to decide whether they are on a light
@@ -1630,6 +1671,48 @@ macro_rules! emulator_conformance_tests {
                 let second = rows[0][1].hyperlink.clone().expect("B is linked");
                 assert_eq!(first.id.as_deref(), Some("one"));
                 assert_eq!(second.id.as_deref(), Some("two"));
+            }
+        }
+
+        /// Every way onto the alternate screen is reported as being on it.
+        ///
+        /// `?1049` is what a full-screen program sends, and every backend
+        /// honors it. `?47` and `?1047` are the older spellings, without the
+        /// cursor save `?1049` bundles in; alacritty and rio ignore them
+        /// outright.
+        ///
+        /// What must hold everywhere is that the flag and the screen agree: a
+        /// backend that switches buffers has to say so. Ghostty tracks each
+        /// spelling under its own mode, so reading only `?1049` reported the
+        /// primary screen while the alternate one was showing.
+        #[test]
+        fn conformance_alt_screen_flag_follows_the_screen() {
+            use $crate::terminal::emu::TerminalMode;
+            let legacy_ignored = CONFORMANCE_DIVERGENCES
+                .contains(&$crate::terminal::conformance::Divergence::NoLegacyAlternateScreen);
+
+            for (sequence, always) in [
+                (&b"\x1b[?47h"[..], false),
+                (b"\x1b[?1047h", false),
+                (b"\x1b[?1049h", true),
+            ] {
+                let mut e = conformance_emu(10, 3, 100);
+                e.process(b"primary");
+                e.process(sequence);
+                let text = conformance_text(&e.viewable_rows());
+                let showing_alt = !text.iter().any(|r| r.contains("primary"));
+                let name = String::from_utf8_lossy(sequence).to_string();
+
+                assert_eq!(
+                    e.mode(TerminalMode::AlternateScreen),
+                    showing_alt,
+                    "{name}: alternate_screen must agree with the visible screen"
+                );
+                if always || !legacy_ignored {
+                    assert!(showing_alt, "{name} reaches the alternate screen");
+                } else {
+                    assert!(!showing_alt, "{name} is ignored by this backend");
+                }
             }
         }
 

--- a/crates/tui-test/src/terminal/emu.rs
+++ b/crates/tui-test/src/terminal/emu.rs
@@ -168,7 +168,7 @@ impl TerminalMode {
     }
 }
 
-/// SGR mouse events currently requested by the child.
+/// Mouse tracking level currently requested by the child.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum MouseMode {
     #[default]
@@ -242,7 +242,25 @@ impl MouseModeTracker {
         self.parser.advance(&mut self.state, bytes);
     }
 
+    /// The tracking level the child asked for.
+    ///
+    /// Independent of how the child asked for the reports to be encoded:
+    /// `CSI ?1000 h` on its own is click tracking whether or not `CSI ?1006 h`
+    /// followed it, and saying otherwise would report "none" for a program
+    /// that is plainly reading clicks.
     pub(crate) fn mode(&self) -> MouseMode {
+        self.state.tracking
+    }
+
+    /// The tracking level a viewer can relay, which is `None` unless the child
+    /// also asked for SGR encoding.
+    ///
+    /// The monitor mirrors the child's tracking onto the watching terminal and
+    /// forwards what comes back. It can only encode SGR, so relaying to a
+    /// child that asked for the legacy `CSI M` form would feed it reports it
+    /// cannot parse. That is a limit of the relay, not a statement about what
+    /// the child requested, which is why it is separate from `mode`.
+    pub(crate) fn relayable(&self) -> MouseMode {
         if self.state.sgr {
             self.state.tracking
         } else {
@@ -524,22 +542,48 @@ mod tests {
     use super::*;
 
     #[test]
-    fn tracks_only_sgr_mouse_modes() {
+    fn tracking_is_reported_whatever_the_encoding() {
         let mut tracker = MouseModeTracker::new();
         tracker.process(b"\x1b[?1000h");
-        assert_eq!(tracker.mode(), MouseMode::None);
-        tracker.process(b"\x1b[?1006h");
-        assert_eq!(tracker.mode(), MouseMode::Click);
+        assert_eq!(
+            tracker.mode(),
+            MouseMode::Click,
+            "?1000h alone is click tracking, in the legacy encoding"
+        );
         tracker.process(b"\x1b[?1002h");
-        assert_eq!(tracker.mode(), MouseMode::Drag);
+        assert_eq!(tracker.mode(), MouseMode::Drag, "?1002h replaces ?1000h");
         tracker.process(b"\x1b[?10");
         tracker.process(b"03h");
-        assert_eq!(tracker.mode(), MouseMode::Motion);
+        assert_eq!(tracker.mode(), MouseMode::Motion, "split across writes");
+        tracker.process(b"\x1b[?1003l");
+        assert_eq!(tracker.mode(), MouseMode::None);
+        tracker.process(b"\x1b[?1000h\x1bc");
+        assert_eq!(tracker.mode(), MouseMode::None, "RIS clears tracking");
+    }
+
+    #[test]
+    fn only_sgr_encoded_tracking_can_be_relayed() {
+        let mut tracker = MouseModeTracker::new();
+        tracker.process(b"\x1b[?1000h");
+        assert_eq!(
+            tracker.relayable(),
+            MouseMode::None,
+            "the legacy encoding is not something the monitor can speak"
+        );
+        tracker.process(b"\x1b[?1006h");
+        assert_eq!(tracker.relayable(), MouseMode::Click);
+        tracker.process(b"\x1b[?1002h");
+        assert_eq!(tracker.relayable(), MouseMode::Drag);
         tracker.process(b"\x1b[?1016h");
-        assert_eq!(tracker.mode(), MouseMode::None);
-        tracker.process(b"\x1b[?1006h\x1b[?1003l");
-        assert_eq!(tracker.mode(), MouseMode::None);
-        tracker.process(b"\x1b[?1000;1006h\x1bc");
-        assert_eq!(tracker.mode(), MouseMode::None);
+        assert_eq!(
+            tracker.relayable(),
+            MouseMode::None,
+            "pixel coordinates are not the SGR cells the monitor sends"
+        );
+        assert_eq!(
+            tracker.mode(),
+            MouseMode::Drag,
+            "but the child is still tracking drags"
+        );
     }
 }

--- a/crates/tui-test/src/terminal/emu.rs
+++ b/crates/tui-test/src/terminal/emu.rs
@@ -28,6 +28,27 @@ pub enum CursorShape {
     Bar,
 }
 
+impl CursorShape {
+    /// The name this shape goes by on the wire.
+    pub const fn name(self) -> &'static str {
+        match self {
+            CursorShape::Block => "block",
+            CursorShape::Underline => "underline",
+            CursorShape::Bar => "bar",
+        }
+    }
+
+    /// Parse a wire name, or `None` when it is not a shape.
+    pub fn parse(name: &str) -> Option<Self> {
+        match name {
+            "block" => Some(CursorShape::Block),
+            "underline" => Some(CursorShape::Underline),
+            "bar" => Some(CursorShape::Bar),
+            _ => None,
+        }
+    }
+}
+
 bitflags::bitflags! {
     /// Kitty keyboard protocol flags currently requested by the child.
     #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -70,11 +91,17 @@ pub enum TerminalMode {
     BracketedPaste,
     /// `CSI ?1049 h`: the alternate screen is showing.
     AlternateScreen,
+    /// `DECTCEM` (`CSI ?25 h`): the cursor is drawn.
+    ///
+    /// Not in xterm.js's `modes`, but every backend already had to answer it
+    /// for the renderer, so it is reported from the same place
+    /// [`Emulator::cursor_visible`] always was.
+    CursorVisible,
 }
 
 impl TerminalMode {
     /// Every mode, so a caller can report the whole set without listing it.
-    pub const ALL: [TerminalMode; 8] = [
+    pub const ALL: [TerminalMode; 9] = [
         TerminalMode::ApplicationCursorKeys,
         TerminalMode::ApplicationKeypad,
         TerminalMode::Origin,
@@ -83,6 +110,7 @@ impl TerminalMode {
         TerminalMode::FocusEvents,
         TerminalMode::BracketedPaste,
         TerminalMode::AlternateScreen,
+        TerminalMode::CursorVisible,
     ];
 
     /// The name this mode goes by on the wire.
@@ -96,6 +124,7 @@ impl TerminalMode {
             TerminalMode::FocusEvents => "focus_events",
             TerminalMode::BracketedPaste => "bracketed_paste",
             TerminalMode::AlternateScreen => "alternate_screen",
+            TerminalMode::CursorVisible => "cursor_visible",
         }
     }
 
@@ -110,6 +139,7 @@ impl TerminalMode {
             TerminalMode::FocusEvents => b"\x1b[?1004h",
             TerminalMode::BracketedPaste => b"\x1b[?2004h",
             TerminalMode::AlternateScreen => b"\x1b[?1049h",
+            TerminalMode::CursorVisible => b"\x1b[?25h",
         }
     }
 
@@ -124,15 +154,17 @@ impl TerminalMode {
             TerminalMode::FocusEvents => b"\x1b[?1004l",
             TerminalMode::BracketedPaste => b"\x1b[?2004l",
             TerminalMode::AlternateScreen => b"\x1b[?1049l",
+            TerminalMode::CursorVisible => b"\x1b[?25l",
         }
     }
 
     /// Whether the mode is on when a terminal has been told nothing.
     ///
-    /// `DECAWM` is the one that starts on: a terminal that did not wrap would
-    /// lose every character past the right margin.
+    /// `DECAWM` and `DECTCEM` are the two that start on: a terminal that did
+    /// not wrap would lose every character past the right margin, and one
+    /// that hid its cursor would need telling before it showed one.
     pub const fn default_enabled(self) -> bool {
-        matches!(self, TerminalMode::Wraparound)
+        matches!(self, TerminalMode::Wraparound | TerminalMode::CursorVisible)
     }
 }
 
@@ -423,7 +455,13 @@ pub trait Emulator: Send {
     /// `DECTCEM` (`CSI ?25 h` and `l`). Full-screen programs routinely hide it
     /// while repainting, so a screenshot that ignored this would show a cursor
     /// parked wherever the last write happened to leave it.
-    fn cursor_visible(&self) -> bool;
+    /// Whether the cursor is being drawn.
+    ///
+    /// A named shorthand for [`TerminalMode::CursorVisible`], kept because
+    /// the renderer asks this on every frame and reads better for it.
+    fn cursor_visible(&self) -> bool {
+        self.mode(TerminalMode::CursorVisible)
+    }
 
     /// The shape the cursor is currently drawn as.
     fn cursor_shape(&self) -> CursorShape;

--- a/crates/tui-test/src/terminal/emu.rs
+++ b/crates/tui-test/src/terminal/emu.rs
@@ -178,6 +178,18 @@ pub enum MouseMode {
     Motion,
 }
 
+impl MouseMode {
+    /// The name this tracking level goes by on the wire.
+    pub const fn name(self) -> &'static str {
+        match self {
+            MouseMode::None => "none",
+            MouseMode::Click => "click",
+            MouseMode::Drag => "drag",
+            MouseMode::Motion => "motion",
+        }
+    }
+}
+
 #[derive(Default)]
 struct MouseModeState {
     tracking: MouseMode,
@@ -395,13 +407,6 @@ pub trait Emulator: Send {
     /// ever enabled, and no test would catch it.
     fn mode(&self, mode: TerminalMode) -> bool;
 
-    /// Whether the child asked for bracketed paste.
-    ///
-    /// A named shorthand for the mode of the same name, kept because pasting
-    /// is the one place the daemon has to branch on a mode by itself.
-    fn bracketed_paste_mode(&self) -> bool {
-        self.mode(TerminalMode::BracketedPaste)
-    }
     /// Encode one key event with the backend's own key encoder.
     ///
     /// `None` means the backend has no encoder, or has one that cannot express
@@ -457,8 +462,15 @@ pub trait Emulator: Send {
     /// parked wherever the last write happened to leave it.
     /// Whether the cursor is being drawn.
     ///
-    /// A named shorthand for [`TerminalMode::CursorVisible`], kept because
-    /// the renderer asks this on every frame and reads better for it.
+    /// Kept as a named method, unlike the other modes, because it belongs to
+    /// the cursor group beside [`Emulator::cursor`] and
+    /// [`Emulator::cursor_shape`]. `DECSCUSR` is a shape rather than a
+    /// boolean, so that group cannot collapse into [`Emulator::mode`]
+    /// anyway, and splitting it so that two thirds of the cursor is asked for
+    /// one way and the rest another would read worse than either.
+    ///
+    /// It is one defaulted line over the real answer, so there is still a
+    /// single implementation per backend.
     fn cursor_visible(&self) -> bool {
         self.mode(TerminalMode::CursorVisible)
     }

--- a/crates/tui-test/src/terminal/emu.rs
+++ b/crates/tui-test/src/terminal/emu.rs
@@ -40,6 +40,102 @@ bitflags::bitflags! {
     }
 }
 
+/// A terminal mode a test can ask about.
+///
+/// Deliberately a closed set rather than a mode number, because the point is
+/// that every backend answers the same question the same way. A variant earns
+/// its place only when all four backends can report it: alacritty and rio from
+/// their `Mode` bitflags, ghostty from `Terminal::mode`, and xterm.js from its
+/// `modes` object, whose fixed set is the binding constraint. Modes that only
+/// some backends track are left out rather than reported as `false`, which
+/// would be a wrong answer dressed as a real one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TerminalMode {
+    /// `DECCKM` (`CSI ?1 h`): cursor keys send `SS3` instead of `CSI`.
+    ApplicationCursorKeys,
+    /// `DECKPAM` (`ESC =`): the keypad sends application sequences.
+    ///
+    /// Driven by `DECKPAM`/`DECKPNM` rather than `CSI ?66 h`, which alacritty
+    /// and rio do not implement: the escape form is the one all four honor.
+    ApplicationKeypad,
+    /// `DECOM` (`CSI ?6 h`): the cursor is confined to the scroll region.
+    Origin,
+    /// `DECAWM` (`CSI ?7 h`): text wraps at the right margin.
+    Wraparound,
+    /// `IRM` (`CSI 4 h`): printed text shifts the rest of the line right.
+    Insert,
+    /// `CSI ?1004 h`: the child is told when the terminal gains or loses focus.
+    FocusEvents,
+    /// `CSI ?2004 h`: pasted text is wrapped in `ESC [200~` and `ESC [201~`.
+    BracketedPaste,
+    /// `CSI ?1049 h`: the alternate screen is showing.
+    AlternateScreen,
+}
+
+impl TerminalMode {
+    /// Every mode, so a caller can report the whole set without listing it.
+    pub const ALL: [TerminalMode; 8] = [
+        TerminalMode::ApplicationCursorKeys,
+        TerminalMode::ApplicationKeypad,
+        TerminalMode::Origin,
+        TerminalMode::Wraparound,
+        TerminalMode::Insert,
+        TerminalMode::FocusEvents,
+        TerminalMode::BracketedPaste,
+        TerminalMode::AlternateScreen,
+    ];
+
+    /// The name this mode goes by on the wire.
+    pub const fn name(self) -> &'static str {
+        match self {
+            TerminalMode::ApplicationCursorKeys => "application_cursor_keys",
+            TerminalMode::ApplicationKeypad => "application_keypad",
+            TerminalMode::Origin => "origin",
+            TerminalMode::Wraparound => "wraparound",
+            TerminalMode::Insert => "insert",
+            TerminalMode::FocusEvents => "focus_events",
+            TerminalMode::BracketedPaste => "bracketed_paste",
+            TerminalMode::AlternateScreen => "alternate_screen",
+        }
+    }
+
+    /// The sequence that turns this mode on, for tests and documentation.
+    pub const fn set_sequence(self) -> &'static [u8] {
+        match self {
+            TerminalMode::ApplicationCursorKeys => b"\x1b[?1h",
+            TerminalMode::ApplicationKeypad => b"\x1b=",
+            TerminalMode::Origin => b"\x1b[?6h",
+            TerminalMode::Wraparound => b"\x1b[?7h",
+            TerminalMode::Insert => b"\x1b[4h",
+            TerminalMode::FocusEvents => b"\x1b[?1004h",
+            TerminalMode::BracketedPaste => b"\x1b[?2004h",
+            TerminalMode::AlternateScreen => b"\x1b[?1049h",
+        }
+    }
+
+    /// The sequence that turns this mode off.
+    pub const fn reset_sequence(self) -> &'static [u8] {
+        match self {
+            TerminalMode::ApplicationCursorKeys => b"\x1b[?1l",
+            TerminalMode::ApplicationKeypad => b"\x1b>",
+            TerminalMode::Origin => b"\x1b[?6l",
+            TerminalMode::Wraparound => b"\x1b[?7l",
+            TerminalMode::Insert => b"\x1b[4l",
+            TerminalMode::FocusEvents => b"\x1b[?1004l",
+            TerminalMode::BracketedPaste => b"\x1b[?2004l",
+            TerminalMode::AlternateScreen => b"\x1b[?1049l",
+        }
+    }
+
+    /// Whether the mode is on when a terminal has been told nothing.
+    ///
+    /// `DECAWM` is the one that starts on: a terminal that did not wrap would
+    /// lose every character past the right margin.
+    pub const fn default_enabled(self) -> bool {
+        matches!(self, TerminalMode::Wraparound)
+    }
+}
+
 /// SGR mouse events currently requested by the child.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum MouseMode {
@@ -260,8 +356,19 @@ pub trait Emulator: Send {
     }
 
     /// Whether the child enabled bracketed paste mode.
+    /// Whether a terminal mode is currently set.
+    ///
+    /// Required rather than defaulted: a backend that silently answered
+    /// `false` for everything would look like a terminal where nothing is
+    /// ever enabled, and no test would catch it.
+    fn mode(&self, mode: TerminalMode) -> bool;
+
+    /// Whether the child asked for bracketed paste.
+    ///
+    /// A named shorthand for the mode of the same name, kept because pasting
+    /// is the one place the daemon has to branch on a mode by itself.
     fn bracketed_paste_mode(&self) -> bool {
-        false
+        self.mode(TerminalMode::BracketedPaste)
     }
     /// Encode one key event with the backend's own key encoder.
     ///

--- a/crates/tui-test/src/terminal/emu.rs
+++ b/crates/tui-test/src/terminal/emu.rs
@@ -89,7 +89,12 @@ pub enum TerminalMode {
     FocusEvents,
     /// `CSI ?2004 h`: pasted text is wrapped in `ESC [200~` and `ESC [201~`.
     BracketedPaste,
-    /// `CSI ?1049 h`: the alternate screen is showing.
+    /// The alternate screen is showing.
+    ///
+    /// Reached by `CSI ?1049 h`, and also by the older `CSI ?47 h` and
+    /// `CSI ?1047 h` on the backends that honor them. This reports the screen
+    /// itself rather than any one of those, so it is true however a program
+    /// got there.
     AlternateScreen,
     /// `DECTCEM` (`CSI ?25 h`): the cursor is drawn.
     ///
@@ -129,6 +134,11 @@ impl TerminalMode {
     }
 
     /// The sequence that turns this mode on, for tests and documentation.
+    ///
+    /// One sequence per mode, not every sequence that reaches it: the
+    /// alternate screen also answers to `CSI ?47 h` and `CSI ?1047 h`, and
+    /// `?1049` is named here because it is what a full-screen program sends
+    /// and the only one every backend honors.
     pub const fn set_sequence(self) -> &'static [u8] {
         match self {
             TerminalMode::ApplicationCursorKeys => b"\x1b[?1h",
@@ -144,6 +154,10 @@ impl TerminalMode {
     }
 
     /// The sequence that turns this mode off.
+    ///
+    /// The counterpart to [`Self::set_sequence`]. `CSI ?1049 l` leaves the
+    /// alternate screen whichever sequence entered it, since the three share
+    /// one screen.
     pub const fn reset_sequence(self) -> &'static [u8] {
         match self {
             TerminalMode::ApplicationCursorKeys => b"\x1b[?1l",

--- a/crates/tui-test/src/terminal/ghostty/core.rs
+++ b/crates/tui-test/src/terminal/ghostty/core.rs
@@ -14,7 +14,7 @@ use ghostty_vt::key::{
     Mods as GhosttyMods, OptionAsAlt,
 };
 use ghostty_vt::render::{CellIterator, CursorVisualStyle, RowIterator};
-use ghostty_vt::screen::{Cell as GhosttyCell, CellContentTag, CellWide, GridRef};
+use ghostty_vt::screen::{Cell as GhosttyCell, CellContentTag, CellWide, GridRef, Screen};
 use ghostty_vt::style::{Palette, PaletteIndex, RgbColor, Style, StyleColor, Underline};
 use ghostty_vt::terminal::{
     ConformanceLevel, DeviceAttributeFeature, DeviceAttributes, DeviceType, Mode, Point,
@@ -271,26 +271,24 @@ impl GhosttyCore {
     }
 
     pub(super) fn mode(&self, mode: TerminalMode) -> Result<bool> {
-        // Ghostty honors all three ways into the alternate screen and tracks
-        // each under its own flag: `?47`, `?1047` and `?1049`. The question
-        // `alternate_screen` asks is whether the alternate screen is showing,
-        // so any of them answers it — reading only `?1049` reported "primary"
-        // while ghostty was plainly displaying the alternate buffer.
+        // Ghostty honors all three ways onto the alternate screen — `?47`,
+        // `?1047` and `?1049` — and they share one screen: each dispatches to
+        // `switchScreenMode`, which moves the same `screens.active_key`. The
+        // *mode bits* are what is separate. `setMode` sets one bit per mode
+        // before dispatching, and nothing syncs them, so `?47h` followed by
+        // `?1049l` leaves bit 47 set while the primary screen is showing.
+        //
+        // So no mode bit answers "which screen is showing": reading `?1049`
+        // alone missed the other two entries, and reading all three claimed
+        // the alternate screen after `?1049l` had left it. Ghostty tracks the
+        // active screen directly, which is the question being asked.
         if mode == TerminalMode::AlternateScreen {
-            for flag in [
-                Mode::ALT_SCREEN_SAVE,
-                Mode::ALT_SCREEN,
-                Mode::ALT_SCREEN_LEGACY,
-            ] {
-                if self
-                    .terminal
-                    .mode(flag)
-                    .with_context(|| format!("reading {} mode", mode.name()))?
-                {
-                    return Ok(true);
-                }
-            }
-            return Ok(false);
+            return Ok(matches!(
+                self.terminal
+                    .active_screen()
+                    .context("reading active screen")?,
+                Screen::Alternate
+            ));
         }
         let ghostty_mode = match mode {
             TerminalMode::ApplicationCursorKeys => Mode::DECCKM,

--- a/crates/tui-test/src/terminal/ghostty/core.rs
+++ b/crates/tui-test/src/terminal/ghostty/core.rs
@@ -271,9 +271,27 @@ impl GhosttyCore {
     }
 
     pub(super) fn mode(&self, mode: TerminalMode) -> Result<bool> {
-        // Ghostty tracks `?1049` as the pair it is: a screen swap plus a
-        // cursor save. `ALT_SCREEN_SAVE` is the one `?1049` itself sets, and
-        // it is what a child that sent `?1049` gets told about.
+        // Ghostty honors all three ways into the alternate screen and tracks
+        // each under its own flag: `?47`, `?1047` and `?1049`. The question
+        // `alternate_screen` asks is whether the alternate screen is showing,
+        // so any of them answers it — reading only `?1049` reported "primary"
+        // while ghostty was plainly displaying the alternate buffer.
+        if mode == TerminalMode::AlternateScreen {
+            for flag in [
+                Mode::ALT_SCREEN_SAVE,
+                Mode::ALT_SCREEN,
+                Mode::ALT_SCREEN_LEGACY,
+            ] {
+                if self
+                    .terminal
+                    .mode(flag)
+                    .with_context(|| format!("reading {} mode", mode.name()))?
+                {
+                    return Ok(true);
+                }
+            }
+            return Ok(false);
+        }
         let ghostty_mode = match mode {
             TerminalMode::ApplicationCursorKeys => Mode::DECCKM,
             TerminalMode::ApplicationKeypad => Mode::KEYPAD_KEYS,
@@ -282,7 +300,7 @@ impl GhosttyCore {
             TerminalMode::Insert => Mode::INSERT,
             TerminalMode::FocusEvents => Mode::FOCUS_EVENT,
             TerminalMode::BracketedPaste => Mode::BRACKETED_PASTE,
-            TerminalMode::AlternateScreen => Mode::ALT_SCREEN_SAVE,
+            TerminalMode::AlternateScreen => unreachable!("handled above"),
             TerminalMode::CursorVisible => Mode::CURSOR_VISIBLE,
         };
         self.terminal

--- a/crates/tui-test/src/terminal/ghostty/core.rs
+++ b/crates/tui-test/src/terminal/ghostty/core.rs
@@ -178,7 +178,6 @@ fn cell_from_grid(grid: &GridRef<'_>, links: &mut LinkCache) -> Result<EmuCell> 
 pub(super) struct Frame {
     pub(super) rows: Vec<Vec<EmuCell>>,
     pub(super) cursor: (u16, u16),
-    pub(super) cursor_visible: bool,
     pub(super) cursor_shape: CursorShape,
 }
 
@@ -284,6 +283,7 @@ impl GhosttyCore {
             TerminalMode::FocusEvents => Mode::FOCUS_EVENT,
             TerminalMode::BracketedPaste => Mode::BRACKETED_PASTE,
             TerminalMode::AlternateScreen => Mode::ALT_SCREEN_SAVE,
+            TerminalMode::CursorVisible => Mode::CURSOR_VISIBLE,
         };
         self.terminal
             .mode(ghostty_mode)
@@ -481,9 +481,6 @@ impl GhosttyCore {
                 .context("reading cursor row")?
                 .min(rows.saturating_sub(1)),
         );
-        let cursor_visible = snapshot
-            .cursor_visible()
-            .context("reading cursor visibility")?;
         let cursor_shape = match snapshot
             .cursor_visual_style()
             .context("reading cursor shape")?
@@ -565,7 +562,6 @@ impl GhosttyCore {
         Ok(Frame {
             rows: output,
             cursor,
-            cursor_visible,
             cursor_shape,
         })
     }

--- a/crates/tui-test/src/terminal/ghostty/core.rs
+++ b/crates/tui-test/src/terminal/ghostty/core.rs
@@ -28,7 +28,7 @@ use crate::profile::{xterm_color, ColorSlot, Profile, Rgb};
 use crate::terminal::cell::{
     Attrs, Color, EmuCell, Hyperlink, LinkCache, UnderlineStyle, CONTINUATION,
 };
-use crate::terminal::emu::{Clipboard, ClipboardType, CursorShape, KeyboardMode};
+use crate::terminal::emu::{Clipboard, ClipboardType, CursorShape, KeyboardMode, TerminalMode};
 
 fn to_ghostty_rgb(color: Rgb) -> RgbColor {
     RgbColor {
@@ -271,10 +271,23 @@ impl GhosttyCore {
         self.frame = None;
     }
 
-    pub(super) fn bracketed_paste_mode(&self) -> Result<bool> {
+    pub(super) fn mode(&self, mode: TerminalMode) -> Result<bool> {
+        // Ghostty tracks `?1049` as the pair it is: a screen swap plus a
+        // cursor save. `ALT_SCREEN_SAVE` is the one `?1049` itself sets, and
+        // it is what a child that sent `?1049` gets told about.
+        let ghostty_mode = match mode {
+            TerminalMode::ApplicationCursorKeys => Mode::DECCKM,
+            TerminalMode::ApplicationKeypad => Mode::KEYPAD_KEYS,
+            TerminalMode::Origin => Mode::ORIGIN,
+            TerminalMode::Wraparound => Mode::WRAPAROUND,
+            TerminalMode::Insert => Mode::INSERT,
+            TerminalMode::FocusEvents => Mode::FOCUS_EVENT,
+            TerminalMode::BracketedPaste => Mode::BRACKETED_PASTE,
+            TerminalMode::AlternateScreen => Mode::ALT_SCREEN_SAVE,
+        };
         self.terminal
-            .mode(Mode::BRACKETED_PASTE)
-            .context("reading bracketed paste mode")
+            .mode(ghostty_mode)
+            .with_context(|| format!("reading {} mode", mode.name()))
     }
 
     pub(super) fn take_pending_writes(&mut self) -> Vec<u8> {

--- a/crates/tui-test/src/terminal/ghostty/mod.rs
+++ b/crates/tui-test/src/terminal/ghostty/mod.rs
@@ -17,7 +17,7 @@ use crate::input::keys::KeyPress;
 use crate::profile::{ColorSlot, Profile, Rgb};
 use crate::terminal::cell::EmuCell;
 use crate::terminal::emu::{
-    ClipboardType, ClipboardValidator, CursorShape, Emulator, KeyboardMode,
+    ClipboardType, ClipboardValidator, CursorShape, Emulator, KeyboardMode, TerminalMode,
 };
 
 use self::core::GhosttyCore;
@@ -307,10 +307,8 @@ impl Emulator for GhosttyEmu {
         self.sequences.state.current.clone()
     }
 
-    fn bracketed_paste_mode(&self) -> bool {
-        self.call_result("reading bracketed paste mode", |core| {
-            core.bracketed_paste_mode()
-        })
+    fn mode(&self, mode: TerminalMode) -> bool {
+        self.call_result("reading terminal mode", move |core| core.mode(mode))
     }
 
     fn cursor_visible(&self) -> bool {

--- a/crates/tui-test/src/terminal/ghostty/mod.rs
+++ b/crates/tui-test/src/terminal/ghostty/mod.rs
@@ -311,12 +311,6 @@ impl Emulator for GhosttyEmu {
         self.call_result("reading terminal mode", move |core| core.mode(mode))
     }
 
-    fn cursor_visible(&self) -> bool {
-        self.call_result("reading cursor visibility", |core| {
-            Ok(core.frame()?.cursor_visible)
-        })
-    }
-
     fn cursor_shape(&self) -> CursorShape {
         self.call_result("reading cursor shape", |core| {
             Ok(core.frame()?.cursor_shape)

--- a/crates/tui-test/src/terminal/rio.rs
+++ b/crates/tui-test/src/terminal/rio.rs
@@ -21,7 +21,7 @@ use crate::terminal::cell::{
     Attrs, Color, EmuCell, Hyperlink, LinkCache, UnderlineStyle, CONTINUATION,
 };
 use crate::terminal::emu::{
-    Clipboard, ClipboardType, ClipboardValidator, CursorShape, Emulator, KeyboardMode,
+    Clipboard, ClipboardType, ClipboardValidator, CursorShape, Emulator, KeyboardMode, TerminalMode,
 };
 
 fn clipboard_type(clipboard: RioClipboardType) -> ClipboardType {
@@ -379,8 +379,18 @@ impl Emulator for RioEmu {
         keyboard_mode
     }
 
-    fn bracketed_paste_mode(&self) -> bool {
-        self.term.mode().contains(Mode::BRACKETED_PASTE)
+    fn mode(&self, mode: TerminalMode) -> bool {
+        let flag = match mode {
+            TerminalMode::ApplicationCursorKeys => Mode::APP_CURSOR,
+            TerminalMode::ApplicationKeypad => Mode::APP_KEYPAD,
+            TerminalMode::Origin => Mode::ORIGIN,
+            TerminalMode::Wraparound => Mode::LINE_WRAP,
+            TerminalMode::Insert => Mode::INSERT,
+            TerminalMode::FocusEvents => Mode::FOCUS_IN_OUT,
+            TerminalMode::BracketedPaste => Mode::BRACKETED_PASTE,
+            TerminalMode::AlternateScreen => Mode::ALT_SCREEN,
+        };
+        self.term.mode().contains(flag)
     }
 
     fn resize(&mut self, cols: u16, rows: u16) {

--- a/crates/tui-test/src/terminal/rio.rs
+++ b/crates/tui-test/src/terminal/rio.rs
@@ -460,13 +460,4 @@ mod tests {
         assert_eq!(bells.count(), 2);
         assert_eq!(bells.sequence(), 2);
     }
-
-    #[test]
-    fn tracks_bracketed_paste_mode() {
-        let mut emulator = RioEmu::new(10, 2, &Profile::default());
-        emulator.process(b"\x1b[?2004h");
-        assert!(emulator.bracketed_paste_mode());
-        emulator.process(b"\x1b[?2004l");
-        assert!(!emulator.bracketed_paste_mode());
-    }
 }

--- a/crates/tui-test/src/terminal/rio.rs
+++ b/crates/tui-test/src/terminal/rio.rs
@@ -422,7 +422,12 @@ impl Emulator for RioEmu {
     }
 
     fn cursor_shape(&self) -> CursorShape {
-        match self.term.cursor().content {
+        // `Term::cursor()` masks the shape to `Hidden` whenever the cursor is
+        // not drawn — hidden by `DECTCEM`, or scrolled out of view — which
+        // loses the shape the child actually asked for. `cursor_shape` is the
+        // unmasked field it derives that from, and whether the cursor is drawn
+        // is already reported by `TerminalMode::CursorVisible`.
+        match self.term.cursor_shape {
             RioCursorShape::Underline => CursorShape::Underline,
             RioCursorShape::Beam => CursorShape::Bar,
             RioCursorShape::Block | RioCursorShape::Hidden => CursorShape::Block,
@@ -446,9 +451,10 @@ impl Emulator for RioEmu {
 mod tests {
     use super::*;
 
-    crate::emulator_conformance_tests!(|cols, rows, profile| {
-        Box::new(RioEmu::new(cols, rows, profile))
-    });
+    crate::emulator_conformance_tests!(
+        |cols, rows, profile| { Box::new(RioEmu::new(cols, rows, profile)) },
+        &[crate::terminal::conformance::Divergence::NoLegacyAlternateScreen]
+    );
 
     #[test]
     fn multiple_bells_in_one_chunk_are_counted_individually() {

--- a/crates/tui-test/src/terminal/rio.rs
+++ b/crates/tui-test/src/terminal/rio.rs
@@ -380,6 +380,11 @@ impl Emulator for RioEmu {
     }
 
     fn mode(&self, mode: TerminalMode) -> bool {
+        // rio reports a hidden cursor as a cursor *shape* rather than through
+        // `SHOW_CURSOR`, so this one does not come from the mode bitflags.
+        if mode == TerminalMode::CursorVisible {
+            return !matches!(self.term.cursor().content, RioCursorShape::Hidden);
+        }
         let flag = match mode {
             TerminalMode::ApplicationCursorKeys => Mode::APP_CURSOR,
             TerminalMode::ApplicationKeypad => Mode::APP_KEYPAD,
@@ -389,6 +394,7 @@ impl Emulator for RioEmu {
             TerminalMode::FocusEvents => Mode::FOCUS_IN_OUT,
             TerminalMode::BracketedPaste => Mode::BRACKETED_PASTE,
             TerminalMode::AlternateScreen => Mode::ALT_SCREEN,
+            TerminalMode::CursorVisible => unreachable!("handled above"),
         };
         self.term.mode().contains(flag)
     }
@@ -413,10 +419,6 @@ impl Emulator for RioEmu {
 
     fn title(&self) -> Option<String> {
         (!self.term.title.is_empty()).then(|| self.term.title.clone())
-    }
-
-    fn cursor_visible(&self) -> bool {
-        !matches!(self.term.cursor().content, RioCursorShape::Hidden)
     }
 
     fn cursor_shape(&self) -> CursorShape {

--- a/crates/tui-test/src/terminal/xtermjs.rs
+++ b/crates/tui-test/src/terminal/xtermjs.rs
@@ -29,7 +29,7 @@ use rquickjs::{Context, Ctx, Function, Object, Runtime};
 use crate::event::BellTracker;
 use crate::profile::{ColorSlot, Profile, Rgb};
 use crate::terminal::cell::{Attrs, Color, EmuCell, Hyperlink, UnderlineStyle, CONTINUATION};
-use crate::terminal::emu::{ClipboardValidator, CursorShape, Emulator};
+use crate::terminal::emu::{ClipboardValidator, CursorShape, Emulator, TerminalMode};
 
 const XTERM_BUNDLE: &str = include_str!("../../assets/xtermjs/xterm-headless.js");
 const UNICODE11: &str = include_str!("../../assets/xtermjs/addon-unicode11.js");
@@ -444,8 +444,13 @@ impl Emulator for XtermJsEmu {
         self.call::<String>("takeReplies").into_bytes()
     }
 
-    fn bracketed_paste_mode(&self) -> bool {
-        self.call("bracketedPaste")
+    fn mode(&self, mode: TerminalMode) -> bool {
+        self.invoke("mode", |emu, ctx| {
+            let name = rquickjs::String::from_str(ctx.clone(), mode.name())?;
+            emu.get::<_, Function>("mode")?.call((name,))
+        })
+        .unwrap_or(0i32)
+            != 0
     }
 
     fn resize(&mut self, cols: u16, rows: u16) {

--- a/crates/tui-test/src/terminal/xtermjs.rs
+++ b/crates/tui-test/src/terminal/xtermjs.rs
@@ -601,15 +601,6 @@ mod tests {
         assert_eq!(bells.count(), 1);
     }
 
-    #[test]
-    fn tracks_bracketed_paste_mode() {
-        let mut emulator = XtermJsEmu::new(10, 2, &Profile::default()).expect("create emulator");
-        emulator.process(b"\x1b[?2004h");
-        assert!(emulator.bracketed_paste_mode());
-        emulator.process(b"\x1b[?2004l");
-        assert!(!emulator.bracketed_paste_mode());
-    }
-
     crate::emulator_conformance_tests!(
         |cols, rows, profile| {
             Box::new(XtermJsEmu::new(cols, rows, profile).expect("create xterm.js emulator"))
@@ -628,6 +619,9 @@ mod tests {
             // the bundle contains no handler for `CSI > u`, `CSI = u`, or
             // `CSI < u`, so the modes a child pushes are parsed and dropped.
             crate::terminal::conformance::Divergence::NoKittyKeyboard,
+            // `ESC c` clears every other mode on this backend but leaves a
+            // hidden cursor hidden.
+            crate::terminal::conformance::Divergence::RisDoesNotResetCursorVisibility,
         ]
     );
 }

--- a/crates/tui-test/src/terminal/xtermjs.rs
+++ b/crates/tui-test/src/terminal/xtermjs.rs
@@ -445,6 +445,10 @@ impl Emulator for XtermJsEmu {
     }
 
     fn mode(&self, mode: TerminalMode) -> bool {
+        // Not in xterm.js's `modes`; it lives on the core service instead.
+        if mode == TerminalMode::CursorVisible {
+            return self.call_or("cursorVisible", true);
+        }
         self.invoke("mode", |emu, ctx| {
             let name = rquickjs::String::from_str(ctx.clone(), mode.name())?;
             emu.get::<_, Function>("mode")?.call((name,))
@@ -480,10 +484,6 @@ impl Emulator for XtermJsEmu {
     fn title(&self) -> Option<String> {
         self.call::<Option<String>>("title")
             .filter(|title| !title.is_empty())
-    }
-
-    fn cursor_visible(&self) -> bool {
-        self.call_or("cursorVisible", true)
     }
 
     fn cursor_key_application(&self) -> bool {

--- a/references/cli.md
+++ b/references/cli.md
@@ -143,6 +143,11 @@ Recording modes: `disabled`, `on-failure`, and `always`.
 | `bracketed_paste` | `CSI ?2004 h` | pastes are bracketed |
 | `alternate_screen` | `CSI ?1049 h` | the alternate screen is showing |
 
+Mouse tracking is reported separately, as `mouse_mode`: `none`, `click`,
+`drag`, or `motion`. It is not in the table because it is not a set of
+independent switches — `CSI ?1002 h` replaces `CSI ?1000 h` rather than
+joining it, so booleans would claim two are on when only the last is honoured.
+
 Read them with `get modes`, and assert one with `expect mode <NAME> [--off]`.
 The cursor has its own command, since position and shape have nowhere else to
 live:

--- a/references/cli.md
+++ b/references/cli.md
@@ -80,7 +80,7 @@ Most waits accept `--timeout MS`. `expect`, `click`, and `highlight` retry. `fin
 
 | Command | Use |
 | --- | --- |
-| `state` | Read session state and text. |
+| `state` | Read session state, terminal modes, and text. |
 | `text [--full]` | Read terminal text. |
 | `cells X Y [W H]` | Read cells and styles. |
 | `get FIELD` | Read one field. |
@@ -126,6 +126,25 @@ directory = "./artifacts"
 ```
 
 Recording modes: `disabled`, `on-failure`, and `always`.
+
+## Terminal modes
+
+`state` reports the modes the child has turned on, under `modes`:
+
+| Key | Sequence | Meaning |
+| --- | --- | --- |
+| `application_cursor_keys` | `CSI ?1 h` | cursor keys send `SS3` |
+| `application_keypad` | `ESC =` | keypad sends application sequences |
+| `origin` | `CSI ?6 h` | cursor confined to the scroll region |
+| `wraparound` | `CSI ?7 h` | text wraps at the right margin (on by default) |
+| `insert` | `CSI 4 h` | printed text shifts the line right |
+| `focus_events` | `CSI ?1004 h` | focus changes are reported to the child |
+| `bracketed_paste` | `CSI ?2004 h` | pastes are bracketed |
+| `alternate_screen` | `CSI ?1049 h` | the alternate screen is showing |
+
+Every key is always present, so `false` means off rather than unknown. The set
+is deliberately closed: a mode is listed only when all four backends report it
+identically, which the conformance suite checks.
 
 ## Agent commands
 

--- a/references/cli.md
+++ b/references/cli.md
@@ -134,6 +134,7 @@ Recording modes: `disabled`, `on-failure`, and `always`.
 | Key | Sequence | Meaning |
 | --- | --- | --- |
 | `application_cursor_keys` | `CSI ?1 h` | cursor keys send `SS3` |
+| `cursor_visible` | `CSI ?25 h` | the cursor is drawn (on by default) |
 | `application_keypad` | `ESC =` | keypad sends application sequences |
 | `origin` | `CSI ?6 h` | cursor confined to the scroll region |
 | `wraparound` | `CSI ?7 h` | text wraps at the right margin (on by default) |
@@ -141,6 +142,22 @@ Recording modes: `disabled`, `on-failure`, and `always`.
 | `focus_events` | `CSI ?1004 h` | focus changes are reported to the child |
 | `bracketed_paste` | `CSI ?2004 h` | pastes are bracketed |
 | `alternate_screen` | `CSI ?1049 h` | the alternate screen is showing |
+
+Read them with `get modes`, and assert one with `expect mode <NAME> [--off]`.
+The cursor has its own command, since position and shape have nowhere else to
+live:
+
+```sh
+tui-test get cursor --json          # x, y, visible, shape, color
+tui-test expect cursor --hidden
+tui-test expect cursor --visible --shape bar
+tui-test expect cursor --x 4 --y 0
+tui-test expect mode alternate_screen
+tui-test expect mode bracketed_paste --off
+```
+
+`expect cursor` checks only the properties you name, so asserting a shape
+leaves visibility and position alone.
 
 Every key is always present, so `false` means off rather than unknown. The set
 is deliberately closed: a mode is listed only when all four backends report it

--- a/references/cli.md
+++ b/references/cli.md
@@ -146,7 +146,7 @@ Recording modes: `disabled`, `on-failure`, and `always`.
 Mouse tracking is reported separately, as `mouse_mode`: `none`, `click`,
 `drag`, or `motion`. It is not in the table because it is not a set of
 independent switches — `CSI ?1002 h` replaces `CSI ?1000 h` rather than
-joining it, so booleans would claim two are on when only the last is honoured.
+joining it, so booleans would claim two are on when only the last is honored.
 
 Read them with `get modes`, and assert one with `expect mode <NAME> [--off]`.
 The cursor has its own command, since position and shape have nowhere else to

--- a/references/cli.md
+++ b/references/cli.md
@@ -143,11 +143,13 @@ Recording modes: `disabled`, `on-failure`, and `always`.
 | `bracketed_paste` | `CSI ?2004 h` | pastes are bracketed |
 | `alternate_screen` | `CSI ?1049 h` | the alternate screen is showing |
 
+The `Sequence` column names one way to reach each mode, not every one.
 `alternate_screen` reports whether the alternate screen is showing, however it
-was reached. `CSI ?1049 h` is what a full-screen program sends and every
-backend honors it; the older `CSI ?47 h` and `CSI ?1047 h` are honored by the
-ghostty and xterm.js backends and ignored by alacritty and rio, so prefer
-`?1049` in a test that has to behave the same everywhere.
+was reached: `CSI ?1049 h` is what a full-screen program sends and every
+backend honors it, while the older `CSI ?47 h` and `CSI ?1047 h` are honored
+by the ghostty and xterm.js backends and ignored by alacritty and rio. Prefer
+`?1049` in a test that has to behave the same everywhere. `CSI ?1049 l` leaves
+the alternate screen whichever sequence entered it.
 
 Mouse tracking is reported separately, as `mouse_mode`: `none`, `click`,
 `drag`, or `motion`. It is not in the table because it is not a set of

--- a/references/cli.md
+++ b/references/cli.md
@@ -143,10 +143,19 @@ Recording modes: `disabled`, `on-failure`, and `always`.
 | `bracketed_paste` | `CSI ?2004 h` | pastes are bracketed |
 | `alternate_screen` | `CSI ?1049 h` | the alternate screen is showing |
 
+`alternate_screen` reports whether the alternate screen is showing, however it
+was reached. `CSI ?1049 h` is what a full-screen program sends and every
+backend honors it; the older `CSI ?47 h` and `CSI ?1047 h` are honored by the
+ghostty and xterm.js backends and ignored by alacritty and rio, so prefer
+`?1049` in a test that has to behave the same everywhere.
+
 Mouse tracking is reported separately, as `mouse_mode`: `none`, `click`,
 `drag`, or `motion`. It is not in the table because it is not a set of
 independent switches — `CSI ?1002 h` replaces `CSI ?1000 h` rather than
 joining it, so booleans would claim two are on when only the last is honored.
+It reports the tracking level regardless of how the child asked for the
+reports to be encoded, so `CSI ?1000 h` alone is `click` whether or not
+`CSI ?1006 h` followed it.
 
 Read them with `get modes`, and assert one with `expect mode <NAME> [--off]`.
 The cursor has its own command, since position and shape have nowhere else to


### PR DESCRIPTION
`state` now reports which terminal modes the child has turned on.

## Why

Nothing exposed them. `bracketed_paste_mode` existed for the monitor's own use, and every other mode a program switched on was invisible to a test — you could not assert that a TUI entered the alternate screen, enabled bracketed paste, or turned on focus reporting.

## Is it unanimous?

Yes, for a specific set — which is the whole question, so I checked it rather than assumed it.

| backend | how modes are read |
| --- | --- |
| alacritty | `TermMode` bitflags |
| rio | `Mode` bitflags (a fork of alacritty's) |
| ghostty | `Terminal::mode(Mode)`, ~40 modes |
| xterm.js | `term.modes`, a **fixed set of 10** with no "read mode N" call |

xterm.js is the binding constraint, so the vocabulary is a closed enum rather than a mode number. **Nine modes qualify:**

| Variant | Sequence |
| --- | --- |
| `ApplicationCursorKeys` | `CSI ?1 h` |
| `ApplicationKeypad` | `ESC =` |
| `Origin` | `CSI ?6 h` |
| `Wraparound` | `CSI ?7 h` (on by default) |
| `Insert` | `CSI 4 h` |
| `FocusEvents` | `CSI ?1004 h` |
| `BracketedPaste` | `CSI ?2004 h` |
| `AlternateScreen` | `CSI ?1049 h` |
| `CursorVisible` | `CSI ?25 h` (on by default) |

**Deliberately excluded**, because reporting `false` for a mode a backend cannot see would be a wrong answer dressed as a real one:

- reverse wraparound (`?45`) and synchronized output (`?2026`) — ghostty and xterm.js track them, alacritty and rio do not
- `LNM` (`20`) — alacritty, rio and ghostty track it, xterm.js does not

## Two things the conformance suite found, rather than me assuming

**Application keypad is `DECKPAM`, not `CSI ?66 h`.** My first pass used the private-mode form and the case failed on alacritty and rio, which simply do not implement it. `ESC =` / `ESC >` is the form all four honor.

**The alternate screen is not in xterm.js's `modes`.** It comes from `term.buffer.active.type === 'alternate'`, which reports `alternate` exactly while `?1049` or `?47` is in effect. On ghostty it maps to `ALT_SCREEN_SAVE`, the mode `?1049` itself sets, rather than the legacy `?47`.

## Shape

`Emulator::mode` is **required, not defaulted**. A defaulted `false` would make a backend that forgot to implement it look like a terminal where nothing is ever enabled, and no test would catch it — which is exactly how ghostty's `keyboard_mode` went missing for as long as it did. `bracketed_paste_mode` now delegates to it, leaving one implementation per backend instead of two.

`state.modes` is a map with every key always present, so `false` means off rather than "this build does not know that mode".

## Tests

Two conformance cases, so all four backends are held to the same contract and the enum stays a claim rather than a wish list:

- `conformance_terminal_modes_turn_on_and_off` — each mode starts at its documented default, turns on, and turns off.
- `conformance_terminal_modes_are_independent` — setting one mode leaves the other seven at their defaults, so a backend that mapped two variants onto one flag fails here instead of quietly reporting the wrong one.

Verified against a live session too:

```
$ printf '\033[?1h\033[?2004h\033[?1049h' | ...
{ "alternate_screen": true, "application_cursor_keys": true,
  "application_keypad": false, "bracketed_paste": true,
  "focus_events": false, "insert": false, "origin": false,
  "wraparound": true }

$ printf '\033=\033[?7l' | ...
application_keypad = true   wraparound = false
```

`cargo test --workspace --features tui-test-rs/ghostty,tui-test-rs/rio,tui-test-rs/xtermjs` passes, and both `clippy -D warnings` invocations plus `cargo fmt --check` are clean.

## Cursor

`DECTCEM` qualifies from a different direction than the rest: it is not in xterm.js's `modes`, but every backend already had to answer it for the renderer, so it is reported from the same place `cursor_visible` always was. `cursor_visible` now delegates to `mode`, so each backend answers in one place instead of two — rio still reads a hidden cursor as a cursor *shape*, and ghostty now reads `DECTCEM` directly rather than the render snapshot.

The cursor grows the rest of its state. `state.cursor` and `get cursor` report `visible`, `shape`, and `color` beside `x` and `y`.

## CLI

```sh
tui-test get modes                                   # every mode, as JSON
tui-test get cursor --json                           # x, y, visible, shape, color
tui-test expect mode alternate_screen                # on
tui-test expect mode bracketed_paste --off
tui-test expect cursor --hidden
tui-test expect cursor --visible --shape bar
tui-test expect cursor --x 4 --y 0
```

`expect cursor` is a command rather than sugar for `expect mode cursor_visible`. The cursor has four properties and three of them have nowhere else to live, so it earns a cohesive noun and visibility comes along with it. There is deliberately **no** `expect alt-screen`: it would be a second spelling of a single boolean, and an argument for eight more like it.

`expect cursor` checks only the properties named, so asserting a shape leaves position and visibility alone. `--visible` and `--hidden` are separate flags rather than one optional boolean, so naming neither means "do not care" rather than "must be hidden".

An unknown mode is a usage error that names the set:

```
$ tui-test expect mode nonsense
unknown terminal mode 'nonsense'; expected one of: application_cursor_keys,
application_keypad, origin, wraparound, insert, focus_events,
bracketed_paste, alternate_screen, cursor_visible
```

`OperationResult::State` is now boxed: `modes` pushed it far enough past the other variants to trip `large_enum_variant`, and it is returned from every operation.

## Verified live

```
$ printf '\033[?25l\033[?1049h\033[5 q'
get cursor  -> {"x":0,"y":0,"visible":false,"shape":"bar","color":"#c0c0c0"}
get modes   -> alternate_screen=true, cursor_visible=false, wraparound=true, rest false

expect mode alternate_screen          exit 0
expect mode bracketed_paste           exit 1
expect mode bracketed_paste --off     exit 0
expect cursor --hidden --shape bar    exit 0
expect cursor --visible               exit 1
```

## Not in this PR

A locator/`get_by_style` surface for modes, and JS/Python `expect_mode` helpers — the bindings get `state.modes` and the richer `cursor`, but no dedicated assertion methods yet.
