### PR TITLE
docs: shorten terminal reference guidance

### DIFF
--- a/references/cli.md
+++ b/references/cli.md
@@ -42,7 +42,8 @@ Common options:
 
 Style options: `--fg`, `--bg`, `--bold`, `--dim`, `--italic`, `--underline-style`, `--underline-color`, `--inverse`, `--hidden`, `--strikethrough`, `--blink`, and `--link`.
 
-`--link` matches a cell's OSC 8 target: `--link https://example.com` requires that link, and `--link ""` requires a cell that links nowhere. It applies to every cell of the match, blanks included, because a space inside a link is part of the link. The appearance options skip blanks, which cannot show them, so `A B` linked throughout with only the letters bold matches `--bold --link ...` just as it matches either alone.
+`--link URL` matches that hyperlink on every cell, including spaces.
+Use `--link ""` for unlinked cells. Other style filters ignore spaces.
 
 `click text` also accepts `--button left|middle|right`, `--alt`, `--ctrl`, `--shift`, `--clicks`, and `--timeout`.
 
@@ -60,7 +61,6 @@ Style options: `--fg`, `--bg`, `--bold`, `--dim`, `--italic`, `--underline-style
 | `mouse down\|up X Y [options]` | Press or release a button. |
 | `mouse drag X1 Y1 X2 Y2 [options]` | Drag. |
 | `mouse scroll up\|down [--amount N]` | Scroll. |
-
 | `resize COLS ROWS` | Resize. |
 | `signal NAME` | Send a signal. |
 
@@ -84,13 +84,14 @@ Most waits accept `--timeout MS`. `expect`, `click`, and `highlight` retry. `fin
 
 | Command | Use |
 | --- | --- |
-| `state` | Read session state, terminal modes, and text. |
+| `state` | Read session state, modes, colors, and text. |
 | `text [--full]` | Read terminal text. |
 | `cells X Y [W H]` | Read cells and styles. |
 | `get FIELD` | Read one field. |
 | `screenshot [PATH] [--background COLOR \| --transparent]` | Read text or save SVG or PNG. |
 
-Fields: `command`, `output`, `exit-code`, `cwd`, `cursor`, `size`, `title`, `clipboard`, `bells`, and `bell-events`.
+Fields: `command`, `output`, `exit-code`, `cwd`, `cursor`, `modes`, `colors`,
+`size`, `title`, `clipboard`, `bells`, and `bell-events`.
 
 ## Assert
 
@@ -113,10 +114,8 @@ Fields: `command`, `output`, `exit-code`, `cwd`, `cursor`, `size`, `title`, `cli
 | `monitor` | Watch a session live. |
 | `monitor --interactive` | Forward keyboard, paste, and supported SGR mouse input; Ctrl+] detaches. |
 
-Interactive monitors apply the target's keyboard and paste modes before reading
-input. SGR mouse clicks, drags, and motion are enabled when requested by the
-target, with coordinates translated past the monitor's border. Viewer modes are
-restored on detach; read-only monitoring does not change input modes.
+Interactive input follows the app's keyboard, paste, and mouse modes.
+Detaching restores the viewer's modes; read-only monitoring leaves them unchanged.
 
 ## Configure
 
@@ -133,39 +132,9 @@ Recording modes: `disabled`, `on-failure`, and `always`.
 
 ## Terminal modes
 
-`state` reports the modes the child has turned on, under `modes`:
-
-| Key | Sequence | Meaning |
-| --- | --- | --- |
-| `application_cursor_keys` | `CSI ?1 h` | cursor keys send `SS3` |
-| `cursor_visible` | `CSI ?25 h` | the cursor is drawn (on by default) |
-| `application_keypad` | `ESC =` | keypad sends application sequences |
-| `origin` | `CSI ?6 h` | cursor confined to the scroll region |
-| `wraparound` | `CSI ?7 h` | text wraps at the right margin (on by default) |
-| `insert` | `CSI 4 h` | printed text shifts the line right |
-| `focus_events` | `CSI ?1004 h` | focus changes are reported to the child |
-| `bracketed_paste` | `CSI ?2004 h` | pastes are bracketed |
-| `alternate_screen` | `CSI ?1049 h` | the alternate screen is showing |
-
-The `Sequence` column names one way to reach each mode, not every one.
-`alternate_screen` reports whether the alternate screen is showing, however it
-was reached: `CSI ?1049 h` is what a full-screen program sends and every
-backend honors it, while the older `CSI ?47 h` and `CSI ?1047 h` are honored
-by the ghostty and xterm.js backends and ignored by alacritty and rio. Prefer
-`?1049` in a test that has to behave the same everywhere. `CSI ?1049 l` leaves
-the alternate screen whichever sequence entered it.
-
-Mouse tracking is reported separately, as `mouse_mode`: `none`, `click`,
-`drag`, or `motion`. It is not in the table because it is not a set of
-independent switches — `CSI ?1002 h` replaces `CSI ?1000 h` rather than
-joining it, so booleans would claim two are on when only the last is honored.
-It reports the tracking level regardless of how the child asked for the
-reports to be encoded, so `CSI ?1000 h` alone is `click` whether or not
-`CSI ?1006 h` followed it.
-
-Read them with `get modes`, and assert one with `expect mode <NAME> [--off]`.
-The cursor has its own command, since position and shape have nowhere else to
-live:
+`get modes` and `state.modes` report boolean modes; all keys are present.
+`state.mouse_mode` is `none`, `click`, `drag`, or `motion`.
+Use `expect mode NAME [--off]` to check a mode.
 
 ```sh
 tui-test get cursor --json          # x, y, visible, shape, color
@@ -176,30 +145,15 @@ tui-test expect mode alternate_screen
 tui-test expect mode bracketed_paste --off
 ```
 
-`expect cursor` checks only the properties you name, so asserting a shape
-leaves visibility and position alone.
-
-Every key is always present, so `false` means off rather than unknown. The set
-is deliberately closed: a mode is listed only when all four backends report it
-identically, which the conformance suite checks.
+`expect cursor` checks only the properties you name. Cursor visibility and
+wrapping are on by default. For portable alternate-screen tests, use
+`CSI ?1049 h` to enter and `CSI ?1049 l` to exit.
 
 ## Terminal colors
 
-`state` reports the colors the terminal is painting with, under `colors`:
-
-| Key | Sequence | Meaning |
-| --- | --- | --- |
-| `foreground` | `OSC 10` | the default foreground |
-| `background` | `OSC 11` | the default background |
-| `cursor` | `OSC 12` | the cursor color |
-| `palette` | `OSC 4` | palette entries a program overrode, keyed by index |
-
-The three defaults are always reported, resolved through the profile so a slot
-nothing has touched still has an answer. `palette` lists only the entries that
-differ from the profile, so it names what a program changed rather than all
-256 slots, and `OSC 104` empties it again.
-
-Read them with `get colors`, and assert them with `expect colors`:
+`get colors` and `state.colors` report `foreground`, `background`, `cursor`,
+and `palette` entries that differ from the profile. Unchanged defaults use
+the session profile.
 
 ```sh
 tui-test get colors --json                       # foreground, background, cursor, palette
@@ -208,15 +162,9 @@ tui-test expect colors --foreground 7 --cursor '#ff0000'
 tui-test expect colors --palette '1=#00ff00' --palette '200=#123456'
 ```
 
-Every color takes the same spellings `--fg` does — a hex value (`#rrggbb`),
-an RGB triple (`r,g,b`), or an ANSI index — except `default`, which has
-nothing to refer to here since these slots *are* the defaults. An index is
-resolved against the session's own palette, so `--background 0` means the
-black this profile paints.
-
-`expect colors` checks only the slots you name, and `--palette` is repeatable.
-All of them are matched together, so a program that recolors several at once
-is asserted as one state rather than a race between polls.
+Colors accept hex RGB, `r,g,b`, or an ANSI index from the session's palette.
+`default` is not accepted. `expect colors` checks the named slots together;
+repeat `--palette` to check multiple entries.
 
 ## Agent commands
 

--- a/references/javascript.md
+++ b/references/javascript.md
@@ -35,7 +35,7 @@ const locator = terminal
 | Method | Use |
 | --- | --- |
 | `getByText(text, options?)` | Match text or regex. |
-| `getByStyle(style, options?)` | Match colors, attributes, or an OSC 8 `link`. |
+| `getByStyle(style, options?)` | Match colors, attributes, or `link` targets. |
 | `any()` | Keep all matches. |
 | `unique()` | Require one match. |
 | `first()`, `last()`, `nth(index)` | Select a match. |

--- a/references/python.md
+++ b/references/python.md
@@ -33,7 +33,7 @@ locator = (
 | Method | Use |
 | --- | --- |
 | `get_by_text(text, **options)` | Match text or regex. |
-| `get_by_style(style, **options)` | Match colors, attributes, or an OSC 8 `link`. |
+| `get_by_style(style, **options)` | Match colors, attributes, or `link` targets. |
 | `any()` | Keep all matches. |
 | `unique()` | Require one match. |
 | `first()`, `last()`, `nth(index)` | Select a match. |


### PR DESCRIPTION
Trim terminal mode, color, hyperlink, and monitor documentation. Keep usage examples and links.